### PR TITLE
chore(bundle): Remove chore scope restriction from semantic-release config (#7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
           "releaseRules": [
             {
               "type": "chore",
-              "scope": "bundle",
               "release": "patch"
             }
           ]


### PR DESCRIPTION
Closes #7 