### PR TITLE
test: Increase test coverage from 63% to 100%

### DIFF
--- a/src/__tests__/Vocal.test.js
+++ b/src/__tests__/Vocal.test.js
@@ -98,7 +98,7 @@ describe('Vocal', () => {
 	describe('instance', () => {
 		it('returns the internal SpeechRecognition instance', () => {
 			const wrapper = new Vocal()
-			expect(wrapper.instance).toBeDefined()
+			expect(wrapper.instance).not.toBeNull()
 		})
 
 		it('throws when setting instance directly', () => {
@@ -232,6 +232,7 @@ describe('Vocal', () => {
 			const wrapper = new Vocal()
 			wrapper.addEventListener(Vocal.eventTypes.START, onStart1)
 			wrapper.addEventListener(Vocal.eventTypes.START, onStart2)
+			expect(wrapper.instance.removeEventListener).toHaveBeenCalledTimes(1)
 			wrapper.instance.start()
 			expect(onStart1).not.toHaveBeenCalled()
 			expect(onStart2).toHaveBeenCalled()

--- a/src/__tests__/Vocal.test.js
+++ b/src/__tests__/Vocal.test.js
@@ -7,13 +7,6 @@ describe('Vocal', () => {
 			expect(Vocal.isSupported).toBe(true)
 		})
 
-		it('returns false when SpeechRecognition is not available', () => {
-			const original = window.SpeechRecognition
-			window.SpeechRecognition = undefined
-			expect(Vocal.isSupported).toBe(false)
-			window.SpeechRecognition = original
-		})
-
 		it('returns false when navigator.permissions is not supported', () => {
 			vi.spyOn(userPermissionsUtils, 'isNavigatorPermissionsSupported').mockReturnValueOnce(false)
 			expect(Vocal.isSupported).toBe(false)
@@ -27,16 +20,24 @@ describe('Vocal', () => {
 		it('throws when setting isSupported directly', () => {
 			expect(() => (Vocal.isSupported = false)).toThrow()
 		})
+
+		describe('when SpeechRecognition is unavailable', () => {
+			let original
+			beforeEach(() => {
+				original = window.SpeechRecognition
+				window.SpeechRecognition = undefined
+			})
+			afterEach(() => {
+				window.SpeechRecognition = original
+			})
+
+			it('returns false', () => {
+				expect(Vocal.isSupported).toBe(false)
+			})
+		})
 	})
 
 	describe('constructor', () => {
-		it('throws DOMException when SpeechRecognition is not available', () => {
-			const original = window.SpeechRecognition
-			window.SpeechRecognition = undefined
-			expect(() => new Vocal()).toThrow(DOMException)
-			window.SpeechRecognition = original
-		})
-
 		it('applies default options', () => {
 			const wrapper = new Vocal()
 			expect(wrapper.instance.lang).toBe('en-US')
@@ -53,22 +54,44 @@ describe('Vocal', () => {
 
 		it('assigns SpeechGrammarList instance when grammars is null and SpeechGrammarList is available', () => {
 			const wrapper = new Vocal()
-			expect(wrapper.instance.grammars).toBeDefined()
 			expect(wrapper.instance.grammars).not.toBeNull()
-		})
-
-		it('leaves grammars null when SpeechGrammarList is not available', () => {
-			const original = window.SpeechGrammarList
-			window.SpeechGrammarList = undefined
-			const wrapper = new Vocal()
-			expect(wrapper.instance.grammars).toBeNull()
-			window.SpeechGrammarList = original
 		})
 
 		it('uses provided grammars value when non-null', () => {
 			const grammars = { items: [] }
 			const wrapper = new Vocal({ grammars })
 			expect(wrapper.instance.grammars).toBe(grammars)
+		})
+
+		describe('when SpeechRecognition is unavailable', () => {
+			let original
+			beforeEach(() => {
+				original = window.SpeechRecognition
+				window.SpeechRecognition = undefined
+			})
+			afterEach(() => {
+				window.SpeechRecognition = original
+			})
+
+			it('throws DOMException', () => {
+				expect(() => new Vocal()).toThrow(DOMException)
+			})
+		})
+
+		describe('when SpeechGrammarList is unavailable', () => {
+			let original
+			beforeEach(() => {
+				original = window.SpeechGrammarList
+				window.SpeechGrammarList = undefined
+			})
+			afterEach(() => {
+				window.SpeechGrammarList = original
+			})
+
+			it('leaves grammars null', () => {
+				const wrapper = new Vocal()
+				expect(wrapper.instance.grammars).toBeNull()
+			})
 		})
 	})
 
@@ -96,7 +119,7 @@ describe('Vocal', () => {
 			const onError = vi.fn()
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(null)
 			const wrapper = new Vocal()
-			wrapper.addEventListener('error', onError)
+			wrapper.addEventListener(Vocal.eventTypes.ERROR, onError)
 			await wrapper.start()
 			expect(onError).toHaveBeenCalledWith(new Error('Unable to retrieve the stream from media device'))
 		})
@@ -108,7 +131,7 @@ describe('Vocal', () => {
 				throw error
 			})
 			const wrapper = new Vocal()
-			wrapper.addEventListener('error', onError)
+			wrapper.addEventListener(Vocal.eventTypes.ERROR, onError)
 			await wrapper.start()
 			expect(onError).toHaveBeenCalledWith(error)
 		})
@@ -121,8 +144,10 @@ describe('Vocal', () => {
 
 		it('does nothing when instance is null', async () => {
 			const wrapper = new Vocal()
+			const instance = wrapper.instance
 			wrapper.cleanup()
-			await expect(wrapper.start()).resolves.toBe(wrapper)
+			await wrapper.start()
+			expect(instance.start).not.toHaveBeenCalled()
 		})
 
 		it('returns this for chaining', async () => {
@@ -174,7 +199,7 @@ describe('Vocal', () => {
 		it('registers and calls callback for non-RESULT events', () => {
 			const onStart = vi.fn()
 			const wrapper = new Vocal()
-			wrapper.addEventListener('start', onStart)
+			wrapper.addEventListener(Vocal.eventTypes.START, onStart)
 			wrapper.instance.start()
 			expect(onStart).toHaveBeenCalled()
 		})
@@ -182,7 +207,7 @@ describe('Vocal', () => {
 		it('passes transcript as extra argument for RESULT events', () => {
 			const onResult = vi.fn()
 			const wrapper = new Vocal()
-			wrapper.addEventListener('result', onResult)
+			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
 			wrapper.instance.say('hello world')
 			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'hello world')
 		})
@@ -190,21 +215,23 @@ describe('Vocal', () => {
 		it('does not pass transcript for RESULT events with empty results', () => {
 			const onResult = vi.fn()
 			const wrapper = new Vocal()
-			wrapper.addEventListener('result', onResult)
-			const [, handler] = wrapper.instance.addEventListener.mock.calls.find(([type]) => type === 'result')
-			const event = new Event('result')
+			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
+			const [, handler] = wrapper.instance.addEventListener.mock.calls.find(
+				([type]) => type === Vocal.eventTypes.RESULT
+			)
+			const event = new Event(Vocal.eventTypes.RESULT)
 			event.results = []
 			handler(event)
-			expect(onResult).toHaveBeenCalledWith(event)
-			expect(onResult).not.toHaveBeenCalledWith(expect.anything(), expect.any(String))
+			expect(onResult).toHaveBeenCalledTimes(1)
+			expect(onResult.mock.calls[0]).toHaveLength(1)
 		})
 
 		it('replaces existing listener when same event type is added twice', () => {
 			const onStart1 = vi.fn()
 			const onStart2 = vi.fn()
 			const wrapper = new Vocal()
-			wrapper.addEventListener('start', onStart1)
-			wrapper.addEventListener('start', onStart2)
+			wrapper.addEventListener(Vocal.eventTypes.START, onStart1)
+			wrapper.addEventListener(Vocal.eventTypes.START, onStart2)
 			wrapper.instance.start()
 			expect(onStart1).not.toHaveBeenCalled()
 			expect(onStart2).toHaveBeenCalled()
@@ -213,57 +240,57 @@ describe('Vocal', () => {
 		it('ignores invalid event types', () => {
 			const cb = vi.fn()
 			const wrapper = new Vocal()
-			const callsBefore = wrapper.instance.addEventListener.mock.calls.length
 			wrapper.addEventListener('invalid-type', cb)
-			expect(wrapper.instance.addEventListener.mock.calls.length).toBe(callsBefore)
+			expect(wrapper.instance.addEventListener).not.toHaveBeenCalledWith('invalid-type', expect.any(Function))
 		})
 
 		it('returns this for chaining', () => {
 			const wrapper = new Vocal()
-			expect(wrapper.addEventListener('start', vi.fn())).toBe(wrapper)
+			expect(wrapper.addEventListener(Vocal.eventTypes.START, vi.fn())).toBe(wrapper)
 		})
 	})
 
 	describe('removeEventListener', () => {
 		it('calls removeEventListener on the underlying instance', () => {
 			const wrapper = new Vocal()
-			wrapper.addEventListener('start', vi.fn())
-			wrapper.removeEventListener('start')
+			wrapper.addEventListener(Vocal.eventTypes.START, vi.fn())
+			wrapper.removeEventListener(Vocal.eventTypes.START)
 			expect(wrapper.instance.removeEventListener).toHaveBeenCalled()
 		})
 
 		it('returns this for chaining', () => {
 			const wrapper = new Vocal()
-			wrapper.addEventListener('start', vi.fn())
-			expect(wrapper.removeEventListener('start')).toBe(wrapper)
+			wrapper.addEventListener(Vocal.eventTypes.START, vi.fn())
+			expect(wrapper.removeEventListener(Vocal.eventTypes.START)).toBe(wrapper)
 		})
 	})
 
 	describe('cleanup', () => {
+		let wrapper, instance
+
+		beforeEach(() => {
+			wrapper = new Vocal()
+			instance = wrapper.instance
+		})
+
 		it('calls stop on the instance', () => {
-			const wrapper = new Vocal()
-			const instance = wrapper.instance
 			wrapper.cleanup()
 			expect(instance.stop).toHaveBeenCalled()
 		})
 
 		it('removes all registered listeners', () => {
-			const wrapper = new Vocal()
-			wrapper.addEventListener('start', vi.fn())
-			wrapper.addEventListener('end', vi.fn())
-			const instance = wrapper.instance
+			wrapper.addEventListener(Vocal.eventTypes.START, vi.fn())
+			wrapper.addEventListener(Vocal.eventTypes.END, vi.fn())
 			wrapper.cleanup()
 			expect(instance.removeEventListener).toHaveBeenCalledTimes(2)
 		})
 
 		it('nulls the instance', () => {
-			const wrapper = new Vocal()
 			wrapper.cleanup()
 			expect(wrapper.instance).toBeNull()
 		})
 
 		it('returns this for chaining', () => {
-			const wrapper = new Vocal()
 			expect(wrapper.cleanup()).toBe(wrapper)
 		})
 	})

--- a/src/__tests__/Vocal.test.js
+++ b/src/__tests__/Vocal.test.js
@@ -2,33 +2,269 @@ import Vocal from '../Vocal'
 import * as userPermissionsUtils from '@untemps/user-permissions-utils'
 
 describe('Vocal', () => {
-	it('throws error when setting isSupported explicitly', () => {
-		expect(() => (Vocal.isSupported = false)).toThrow()
-	})
-
-	it('throws error when setting instance explicitly', () => {
-		const wrapper = new Vocal()
-		expect(() => (wrapper.instance = null)).toThrow()
-	})
-
-	it('throws error when getUserMediaStream returns false value', async () => {
-		const onError = vi.fn()
-		vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(null)
-		const wrapper = new Vocal()
-		wrapper.addEventListener('error', onError)
-		await wrapper.start()
-		expect(onError).toHaveBeenCalledWith(new Error('Unable to retrieve the stream from media device'))
-	})
-
-	it('throws error when getUserMediaStream throws', async () => {
-		const onError = vi.fn()
-		const error = new Error('foo')
-		vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockImplementationOnce(() => {
-			throw error
+	describe('isSupported', () => {
+		it('returns true when SpeechRecognition, permissions and mediaDevices are all supported', () => {
+			expect(Vocal.isSupported).toBe(true)
 		})
-		const wrapper = new Vocal()
-		wrapper.addEventListener('error', onError)
-		await wrapper.start()
-		expect(onError).toHaveBeenCalledWith(error)
+
+		it('returns false when SpeechRecognition is not available', () => {
+			const original = window.SpeechRecognition
+			window.SpeechRecognition = undefined
+			expect(Vocal.isSupported).toBe(false)
+			window.SpeechRecognition = original
+		})
+
+		it('returns false when navigator.permissions is not supported', () => {
+			vi.spyOn(userPermissionsUtils, 'isNavigatorPermissionsSupported').mockReturnValueOnce(false)
+			expect(Vocal.isSupported).toBe(false)
+		})
+
+		it('returns false when navigator.mediaDevices is not supported', () => {
+			vi.spyOn(userPermissionsUtils, 'isNavigatorMediaDevicesSupported').mockReturnValueOnce(false)
+			expect(Vocal.isSupported).toBe(false)
+		})
+
+		it('throws when setting isSupported directly', () => {
+			expect(() => (Vocal.isSupported = false)).toThrow()
+		})
+	})
+
+	describe('constructor', () => {
+		it('throws DOMException when SpeechRecognition is not available', () => {
+			const original = window.SpeechRecognition
+			window.SpeechRecognition = undefined
+			expect(() => new Vocal()).toThrow(DOMException)
+			window.SpeechRecognition = original
+		})
+
+		it('applies default options', () => {
+			const wrapper = new Vocal()
+			expect(wrapper.instance.lang).toBe('en-US')
+			expect(wrapper.instance.continuous).toBe(false)
+			expect(wrapper.instance.interimResults).toBe(false)
+			expect(wrapper.instance.maxAlternatives).toBe(1)
+		})
+
+		it('applies custom options', () => {
+			const wrapper = new Vocal({ lang: 'fr-FR', continuous: true })
+			expect(wrapper.instance.lang).toBe('fr-FR')
+			expect(wrapper.instance.continuous).toBe(true)
+		})
+
+		it('assigns SpeechGrammarList instance when grammars is null and SpeechGrammarList is available', () => {
+			const wrapper = new Vocal()
+			expect(wrapper.instance.grammars).toBeDefined()
+			expect(wrapper.instance.grammars).not.toBeNull()
+		})
+
+		it('leaves grammars null when SpeechGrammarList is not available', () => {
+			const original = window.SpeechGrammarList
+			window.SpeechGrammarList = undefined
+			const wrapper = new Vocal()
+			expect(wrapper.instance.grammars).toBeNull()
+			window.SpeechGrammarList = original
+		})
+
+		it('uses provided grammars value when non-null', () => {
+			const grammars = { items: [] }
+			const wrapper = new Vocal({ grammars })
+			expect(wrapper.instance.grammars).toBe(grammars)
+		})
+	})
+
+	describe('instance', () => {
+		it('returns the internal SpeechRecognition instance', () => {
+			const wrapper = new Vocal()
+			expect(wrapper.instance).toBeDefined()
+		})
+
+		it('throws when setting instance directly', () => {
+			const wrapper = new Vocal()
+			expect(() => (wrapper.instance = null)).toThrow()
+		})
+	})
+
+	describe('start', () => {
+		it('calls instance.start when getUserMediaStream returns a stream', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce('stream')
+			const wrapper = new Vocal()
+			await wrapper.start()
+			expect(wrapper.instance.start).toHaveBeenCalled()
+		})
+
+		it('calls error handler when getUserMediaStream returns null', async () => {
+			const onError = vi.fn()
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(null)
+			const wrapper = new Vocal()
+			wrapper.addEventListener('error', onError)
+			await wrapper.start()
+			expect(onError).toHaveBeenCalledWith(new Error('Unable to retrieve the stream from media device'))
+		})
+
+		it('calls error handler when getUserMediaStream throws', async () => {
+			const onError = vi.fn()
+			const error = new Error('foo')
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockImplementationOnce(() => {
+				throw error
+			})
+			const wrapper = new Vocal()
+			wrapper.addEventListener('error', onError)
+			await wrapper.start()
+			expect(onError).toHaveBeenCalledWith(error)
+		})
+
+		it('does not throw when getUserMediaStream fails and no error handler is registered', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(null)
+			const wrapper = new Vocal()
+			await expect(wrapper.start()).resolves.toBe(wrapper)
+		})
+
+		it('does nothing when instance is null', async () => {
+			const wrapper = new Vocal()
+			wrapper.cleanup()
+			await expect(wrapper.start()).resolves.toBe(wrapper)
+		})
+
+		it('returns this for chaining', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce('stream')
+			const wrapper = new Vocal()
+			expect(await wrapper.start()).toBe(wrapper)
+		})
+	})
+
+	describe('stop', () => {
+		it('calls instance.stop', () => {
+			const wrapper = new Vocal()
+			wrapper.stop()
+			expect(wrapper.instance.stop).toHaveBeenCalled()
+		})
+
+		it('returns this for chaining', () => {
+			const wrapper = new Vocal()
+			expect(wrapper.stop()).toBe(wrapper)
+		})
+
+		it('does nothing when instance is null', () => {
+			const wrapper = new Vocal()
+			wrapper.cleanup()
+			expect(() => wrapper.stop()).not.toThrow()
+		})
+	})
+
+	describe('abort', () => {
+		it('calls instance.abort', () => {
+			const wrapper = new Vocal()
+			wrapper.abort()
+			expect(wrapper.instance.abort).toHaveBeenCalled()
+		})
+
+		it('returns this for chaining', () => {
+			const wrapper = new Vocal()
+			expect(wrapper.abort()).toBe(wrapper)
+		})
+
+		it('does nothing when instance is null', () => {
+			const wrapper = new Vocal()
+			wrapper.cleanup()
+			expect(() => wrapper.abort()).not.toThrow()
+		})
+	})
+
+	describe('addEventListener', () => {
+		it('registers and calls callback for non-RESULT events', () => {
+			const onStart = vi.fn()
+			const wrapper = new Vocal()
+			wrapper.addEventListener('start', onStart)
+			wrapper.instance.start()
+			expect(onStart).toHaveBeenCalled()
+		})
+
+		it('passes transcript as extra argument for RESULT events', () => {
+			const onResult = vi.fn()
+			const wrapper = new Vocal()
+			wrapper.addEventListener('result', onResult)
+			wrapper.instance.say('hello world')
+			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'hello world')
+		})
+
+		it('does not pass transcript for RESULT events with empty results', () => {
+			const onResult = vi.fn()
+			const wrapper = new Vocal()
+			wrapper.addEventListener('result', onResult)
+			const [, handler] = wrapper.instance.addEventListener.mock.calls.find(([type]) => type === 'result')
+			const event = new Event('result')
+			event.results = []
+			handler(event)
+			expect(onResult).toHaveBeenCalledWith(event)
+			expect(onResult).not.toHaveBeenCalledWith(expect.anything(), expect.any(String))
+		})
+
+		it('replaces existing listener when same event type is added twice', () => {
+			const onStart1 = vi.fn()
+			const onStart2 = vi.fn()
+			const wrapper = new Vocal()
+			wrapper.addEventListener('start', onStart1)
+			wrapper.addEventListener('start', onStart2)
+			wrapper.instance.start()
+			expect(onStart1).not.toHaveBeenCalled()
+			expect(onStart2).toHaveBeenCalled()
+		})
+
+		it('ignores invalid event types', () => {
+			const cb = vi.fn()
+			const wrapper = new Vocal()
+			const callsBefore = wrapper.instance.addEventListener.mock.calls.length
+			wrapper.addEventListener('invalid-type', cb)
+			expect(wrapper.instance.addEventListener.mock.calls.length).toBe(callsBefore)
+		})
+
+		it('returns this for chaining', () => {
+			const wrapper = new Vocal()
+			expect(wrapper.addEventListener('start', vi.fn())).toBe(wrapper)
+		})
+	})
+
+	describe('removeEventListener', () => {
+		it('calls removeEventListener on the underlying instance', () => {
+			const wrapper = new Vocal()
+			wrapper.addEventListener('start', vi.fn())
+			wrapper.removeEventListener('start')
+			expect(wrapper.instance.removeEventListener).toHaveBeenCalled()
+		})
+
+		it('returns this for chaining', () => {
+			const wrapper = new Vocal()
+			wrapper.addEventListener('start', vi.fn())
+			expect(wrapper.removeEventListener('start')).toBe(wrapper)
+		})
+	})
+
+	describe('cleanup', () => {
+		it('calls stop on the instance', () => {
+			const wrapper = new Vocal()
+			const instance = wrapper.instance
+			wrapper.cleanup()
+			expect(instance.stop).toHaveBeenCalled()
+		})
+
+		it('removes all registered listeners', () => {
+			const wrapper = new Vocal()
+			wrapper.addEventListener('start', vi.fn())
+			wrapper.addEventListener('end', vi.fn())
+			const instance = wrapper.instance
+			wrapper.cleanup()
+			expect(instance.removeEventListener).toHaveBeenCalledTimes(2)
+		})
+
+		it('nulls the instance', () => {
+			const wrapper = new Vocal()
+			wrapper.cleanup()
+			expect(wrapper.instance).toBeNull()
+		})
+
+		it('returns this for chaining', () => {
+			const wrapper = new Vocal()
+			expect(wrapper.cleanup()).toBe(wrapper)
+		})
 	})
 })


### PR DESCRIPTION
## Summary

Add comprehensive tests for all code paths in `Vocal.js`, bringing coverage from 63% to 100% across statements, branches, functions and lines.

## Changes

- Add 37 tests covering all previously untested paths:
  - `isSupported` getter (all true/false branches)
  - `constructor` (DOMException, default options, custom options, SpeechGrammarList branches, grammars override)
  - `instance` getter
  - `start` / `stop` / `abort` (happy path, null instance, chaining)
  - `addEventListener` (non-RESULT events, RESULT with transcript, RESULT with empty results, duplicate listener replacement, invalid event type)
  - `removeEventListener`
  - `cleanup` (stops instance, removes all listeners, nulls instance)

## Coverage

| Metric | Before | After |
|---|---|---|
| Statements | 63.33% | 100% |
| Branches | 44.44% | 100% |
| Functions | 66.66% | 100% |
| Lines | 63.79% | 100% |

## Test plan

- [x] `yarn test:ci` — 37/37 tests pass
- [x] `yarn build` — passes

Closes #5