### PR TITLE
docs: Fix duplicate word typo in README Options and Events sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ vocal.cleanup()
 ## Options
 
 Options described below are those from the `SpeechRecognition` Web API.  
-Please this [this section](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition#properties) for more information.
+Please refer to [this section](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition#properties) for more information.
 
 | Option           | Type              | Default    | Description                                                                                                       |
 | ---------------- | ----------------- | ---------- | ----------------------------------------------------------------------------------------------------------------- |
@@ -67,7 +67,7 @@ Please this [this section](https://developer.mozilla.org/en-US/docs/Web/API/Spee
 ## Events
 
 Events described below are those from the `SpeechRecognition` Web API.  
-Please this [this section](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition#events) for more information.
+Please refer to [this section](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition#events) for more information.
 
 | Event       | Description                                                                               |
 | ----------- | ----------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary

Fix a repeated word typo in the README that appears in both the Options and Events sections.

## Changes

- `README.md`: `"Please this [this section]"` → `"Please refer to [this section]"` (two occurrences)

## Test plan

- [x] No code changes — docs only

Closes #21