### PR TITLE
refactor!: Remove deprecated serviceURI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ Please this [this section](https://developer.mozilla.org/en-US/docs/Web/API/Spee
 | continuous       | boolean           | false      | Whether continuous results are returned for each recognition, or only a single result                             |
 | interimResults   | boolean           | false      | Whether interim results should be returned or not. Interim results are results that are not yet final             |
 | maxAlternatives  | number            | 1          | Maximum number of SpeechRecognitionAlternatives provided per result                                               |
-| serviceURI       | string            | null       | Location of the speech recognition service used by the current SpeechRecognition to handle the actual recognition |
-
 ## Events
 
 Events described below are those from the `SpeechRecognition` Web API.  

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -10,7 +10,6 @@ export interface VocalOptions {
 	continuous?: boolean
 	interimResults?: boolean
 	maxAlternatives?: number
-	serviceURI?: string | null
 }
 
 export type EventType = (typeof Vocal.eventTypes)[keyof typeof Vocal.eventTypes]
@@ -24,7 +23,6 @@ class Vocal {
 		continuous: false,
 		interimResults: false,
 		maxAlternatives: 1,
-		serviceURI: null,
 	}
 
 	static eventTypes = {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -5,7 +5,6 @@ declare interface SpeechRecognition extends EventTarget {
 	interimResults: boolean
 	lang: string
 	maxAlternatives: number
-	serviceURI: string
 	start(): void
 	stop(): void
 	abort(): void


### PR DESCRIPTION
## Summary

Remove the `serviceURI` option which was deprecated and removed from the Web Speech API specification. It had no effect at runtime since browsers already ignore it.

## Changes

- `src/Vocal.ts`: remove `serviceURI` from `VocalOptions` interface and `defaultOptions`
- `src/types.d.ts`: remove `serviceURI` from `SpeechRecognition` interface declaration
- `README.md`: remove `serviceURI` row from Options table

## ⚠️ Breaking changes

- **`VocalOptions.serviceURI`**: removed from the interface. TypeScript users passing `{ serviceURI: '...' }` to the constructor will get a compile error. Runtime behavior is unchanged — the option was already ignored by all browsers.
- Migration: simply remove `serviceURI` from any options object passed to `new Vocal(options)`.

## Test plan

- [x] `yarn test:ci` — 38/38 pass, 100% coverage
- [x] `yarn build` — passes
- [x] `yarn typecheck` — zero TypeScript errors

Closes #22