### PR TITLE
docs: Fix isSupported usage in README Basic Usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,8 @@ Import `Vocal` to a file.
 import { Vocal } from '@untemps/vocal'
 
 // Check whether SpeechRecognition, Permissions and MediaDevices interfaces are supported
-if (!Vocal.isSupported()) {
-  throw "Vocal is not supported"
-  return;
+if (!Vocal.isSupported) {
+  throw new Error('Vocal is not supported')
 }
 
 // Create a Vocal instance (see below for all available option properties)
@@ -35,7 +34,7 @@ const vocal = new Vocal(options)
 vocal.addEventListener('speechstart', (event) => console.log('Vocal starts recording'))
 vocal.addEventListener('speechend', (event) => console.log('Vocal stops recording'))
 vocal.addEventListener('result', (event, result) => console.log('Vocal catches a result'))
-vocal.addEventListener('error', (error) => throw error)
+vocal.addEventListener('error', (error) => { throw error })
 
 // Start recording
 vocal.start()


### PR DESCRIPTION
## Summary

Fix three syntax errors in the README Basic Usage code example that would cause runtime crashes if followed verbatim.

## Changes

- `Vocal.isSupported()` → `Vocal.isSupported` — `isSupported` is a static getter, not a method; calling it with `()` throws `TypeError`
- `throw "Vocal is not supported"` + unreachable `return;` → `throw new Error('Vocal is not supported')` — string throws are poor practice; `return` after `throw` is dead code
- `(error) => throw error` → `(error) => { throw error }` — `throw` is a statement and cannot be used as an arrow function expression body

## Test plan

- [x] No code changes — docs only

Closes #18