### PR TITLE
fix: Expose all RESULT alternatives as third callback argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ const vocal = new Vocal(options)
 // Subscribe to Vocal instance events (see below for all available events)
 vocal.addEventListener('speechstart', (event) => console.log('Vocal starts recording'))
 vocal.addEventListener('speechend', (event) => console.log('Vocal stops recording'))
-vocal.addEventListener('result', (event, result) => console.log('Vocal catches a result'))
+vocal.addEventListener('result', (event, transcript, alternatives) => console.log('Vocal catches a result:', transcript, alternatives))
 vocal.addEventListener('error', (error) => { throw error })
 
 // Start recording

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Please refer to [this section](https://developer.mozilla.org/en-US/docs/Web/API/
 | end         | Fired when the recognition service has disconnected                                       |
 | error       | Fired when a recognition error occurs                                                     |
 | nomatch     | Fired when the recognition service returns a final result with no significant recognition |
-| result      | Fired when the recognition service returns a result                                       |
+| result      | Fired when the recognition service returns a result — callback receives `(event, transcript: string, alternatives: string[])` where `transcript === alternatives[0]` |
 | soundend    | Fired when any sound — recognisable or not — has stopped being detected                   |
 | soundstart  | Fired when any sound — recognisable or not — has been detected                            |
 | speechend   | Fired when speech recognized by the recognition service has stopped being detected        |

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -135,7 +135,7 @@ class Vocal {
 				if (eventType === Vocal.eventTypes.RESULT) {
 					const speechEvent = event as SpeechRecognitionEvent
 					if (speechEvent.results?.length > 0) {
-						const alternatives = Array.from(speechEvent.results[0]).map((alt) => alt.transcript)
+						const alternatives = Array.from(speechEvent.results[0], (alt) => alt.transcript)
 						additionalArgs.push(alternatives[0], alternatives)
 					}
 				}

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -135,7 +135,8 @@ class Vocal {
 				if (eventType === Vocal.eventTypes.RESULT) {
 					const speechEvent = event as SpeechRecognitionEvent
 					if (speechEvent.results?.length > 0) {
-						additionalArgs.push(speechEvent.results[0][0].transcript)
+						const alternatives = Array.from(speechEvent.results[0]).map((alt) => alt.transcript)
+						additionalArgs.push(alternatives[0], alternatives)
 					}
 				}
 

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -235,15 +235,7 @@ describe('Vocal', () => {
 			const onResult = vi.fn()
 			const wrapper = new Vocal()
 			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
-			const [, handler] = (mockInstance(wrapper).addEventListener.mock.calls as string[][]).find(
-				([type]) => type === Vocal.eventTypes.RESULT
-			)!
-			const event = Object.assign(new Event(Vocal.eventTypes.RESULT), {
-				results: [
-					[{ transcript: 'hello' }, { transcript: 'helo' }, { transcript: 'hell' }],
-				],
-			})
-			;(handler as unknown as (e: Event) => void)(event)
+			mockInstance(wrapper).say('hello', ['hello', 'helo', 'hell'])
 			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'hello', ['hello', 'helo', 'hell'])
 		})
 

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -223,12 +223,28 @@ describe('Vocal', () => {
 			expect(onStart).toHaveBeenCalled()
 		})
 
-		it('passes transcript as extra argument for RESULT events', () => {
+		it('passes transcript and alternatives array for RESULT events', () => {
 			const onResult = vi.fn()
 			const wrapper = new Vocal()
 			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
 			mockInstance(wrapper).say('hello world')
-			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'hello world')
+			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'hello world', ['hello world'])
+		})
+
+		it('passes all alternatives when multiple are available', () => {
+			const onResult = vi.fn()
+			const wrapper = new Vocal()
+			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
+			const [, handler] = (mockInstance(wrapper).addEventListener.mock.calls as string[][]).find(
+				([type]) => type === Vocal.eventTypes.RESULT
+			)!
+			const event = Object.assign(new Event(Vocal.eventTypes.RESULT), {
+				results: [
+					[{ transcript: 'hello' }, { transcript: 'helo' }, { transcript: 'hell' }],
+				],
+			})
+			;(handler as unknown as (e: Event) => void)(event)
+			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'hello', ['hello', 'helo', 'hell'])
 		})
 
 		it('does not pass transcript for RESULT events with empty results', () => {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -90,15 +90,16 @@ global.SpeechRecognition = vi.fn(function () {
 		abort: vi.fn(function () {
 			handlers.end?.()
 		}),
-		say: vi.fn(function (sentence: string) {
+		say: vi.fn(function (sentence: string, alternatives?: string[]) {
 			handlers.speechstart?.()
 
+			const alts = alternatives ?? [sentence]
 			const resultEvent = new Event('result') as Event & {
 				resultIndex: number
-				results: [{ transcript: string }][]
+				results: { transcript: string }[][]
 			}
 			resultEvent.resultIndex = 0
-			resultEvent.results = [[{ transcript: sentence }]]
+			resultEvent.results = [alts.map((t) => ({ transcript: t }))]
 			if (sentence) {
 				handlers.result?.(resultEvent)
 			} else {


### PR DESCRIPTION
## Summary

When `maxAlternatives > 1`, the `result` callback previously only received the first alternative's transcript. This fix exposes all alternatives while preserving full backward compatibility.

## Changes

- `src/Vocal.ts`: build `alternatives: string[]` from all entries in `event.results[0]` and pass as third callback argument (transcript stays as second arg)
- `src/__tests__/Vocal.test.ts`: update existing RESULT test, add test for multiple alternatives
- `README.md`: update `result` example to show `(event, transcript, alternatives)`

## API

```js
// Before (still works)
vocal.addEventListener('result', (event, transcript) => console.log(transcript))

// After — access all alternatives
vocal.addEventListener('result', (event, transcript, alternatives) => {
  console.log(transcript)     // string — first alternative (most likely)
  console.log(alternatives)   // string[] — all alternatives
})
```

## Test plan

- [x] `yarn test:ci` — 39/39 pass, 100% coverage
- [x] `yarn build` — passes
- [x] `yarn typecheck` — zero TypeScript errors

Closes #20