### PR TITLE
chore: Add exports field to package.json for proper ESM/CJS resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
 	"types": "dist/index.d.ts",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/index.es.js",
 			"require": "./dist/index.js",
-			"types": "./dist/index.d.ts",
 			"default": "./dist/index.es.js"
 		}
 	},

--- a/package.json
+++ b/package.json
@@ -29,6 +29,13 @@
 	"main": "dist/index.js",
 	"module": "dist/index.es.js",
 	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"import": "./dist/index.es.js",
+			"require": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}
+	},
 	"devDependencies": {
 		"@commitlint/cli": "^21.0.1",
 		"@commitlint/config-conventional": "^21.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
 		".": {
 			"import": "./dist/index.es.js",
 			"require": "./dist/index.js",
-			"types": "./dist/index.d.ts"
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.es.js"
 		}
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary

Add an `exports` field to `package.json` to enable proper conditional module resolution for ESM, CJS, and TypeScript consumers. The existing `main`, `module`, and `types` fields are kept for backward compatibility with bundlers that don't support `exports`.

## Changes

- `package.json`: add `exports["."]` with `import`, `require`, and `types` conditions

## Test plan

- [x] `yarn test:ci` — 39/39 pass, 100% coverage
- [x] `yarn build` — passes
- [x] `yarn typecheck` — zero TypeScript errors

Closes #23