### PR TITLE
test: Add coverage thresholds to vitest config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -31,6 +31,12 @@ export default defineConfig({
 			reporter: ['text', 'lcov'],
 			reportsDirectory: './coverage',
 			exclude: ['vitest.setup.ts'],
+			thresholds: {
+				statements: 100,
+				branches: 100,
+				functions: 100,
+				lines: 100,
+			},
 		},
 	},
 })


### PR DESCRIPTION
## Summary

Add coverage thresholds to the vitest config to enforce the current 100% coverage. Any future PR that drops coverage below 100% on any metric will now fail CI automatically.

## Changes

- `vite.config.js`: add `thresholds: { statements: 100, branches: 100, functions: 100, lines: 100 }` to the coverage block

## Test plan

- [x] `yarn test:ci` — 39/39 pass, thresholds enforced at 100%
- [x] `yarn build` — passes
- [x] `yarn typecheck` — zero TypeScript errors

Closes #24