### PR TITLE
feat: Add isRecording getter to track recognition state

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Please refer to [this section](https://developer.mozilla.org/en-US/docs/Web/API/
 
 ## Getters
 
-| Getter        | Type    | Description                                                                                   |
-| ------------- | ------- | --------------------------------------------------------------------------------------------- |
-| isSupported   | boolean | Whether the current environment supports the SpeechRecognition Web API (static)               |
-| instance      | SpeechRecognition \| null | The underlying SpeechRecognition instance                                   |
-| isRecording   | boolean | Whether recognition is currently active — `true` after `start()`, `false` after `stop()`, `abort()`, or `end` event |
+| Getter      | Type                      | Description                                                                                                          |
+| ----------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| isSupported | boolean                   | Whether the current environment supports the SpeechRecognition Web API (static)                                      |
+| instance    | SpeechRecognition \| null | The underlying SpeechRecognition instance                                                                            |
+| isRecording | boolean                   | Whether recognition is currently active — `true` after `start()`, `false` after `stop()`, `abort()`, or `end` event |

--- a/README.md
+++ b/README.md
@@ -81,3 +81,11 @@ Please refer to [this section](https://developer.mozilla.org/en-US/docs/Web/API/
 | speechend   | Fired when speech recognized by the recognition service has stopped being detected        |
 | speechstart | Fired when sound recognized by the recognition service as speech has been detected        |
 | start       | fired when the recognition service has begun listening to incoming audio                  |
+
+## Getters
+
+| Getter        | Type    | Description                                                                                   |
+| ------------- | ------- | --------------------------------------------------------------------------------------------- |
+| isSupported   | boolean | Whether the current environment supports the SpeechRecognition Web API (static)               |
+| instance      | SpeechRecognition \| null | The underlying SpeechRecognition instance                                   |
+| isRecording   | boolean | Whether recognition is currently active — `true` after `start()`, `false` after `stop()`, `abort()`, or `end` event |

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -55,6 +55,7 @@ class Vocal {
 
 	private _instance: SpeechRecognition | null = null
 	private _listeners: Record<string, EventHandler> | null = null
+	private _isRecording: boolean = false
 
 	constructor(options?: VocalOptions) {
 		const SpeechRecognition = Vocal._resolveSpeechRecognition()
@@ -79,6 +80,10 @@ class Vocal {
 		} else {
 			instance.grammars = grammars
 		}
+
+		this._instance.addEventListener('end', () => {
+			this._isRecording = false
+		})
 	}
 
 	get instance(): SpeechRecognition | null {
@@ -89,6 +94,14 @@ class Vocal {
 		throw new Error('You cannot set instance directly.')
 	}
 
+	get isRecording(): boolean {
+		return this._isRecording
+	}
+
+	set isRecording(_: boolean) {
+		throw new Error('You cannot set isRecording directly.')
+	}
+
 	async start(): Promise<this> {
 		if (this._instance) {
 			try {
@@ -97,6 +110,7 @@ class Vocal {
 					throw new Error('Unable to retrieve the stream from media device')
 				}
 				this._instance.start()
+				this._isRecording = true
 			} catch (error) {
 				const errorHandler = this._listeners?.error
 				if (errorHandler) {
@@ -111,6 +125,7 @@ class Vocal {
 	stop(): this {
 		if (this._instance) {
 			this._instance.stop()
+			this._isRecording = false
 		}
 
 		return this
@@ -119,6 +134,7 @@ class Vocal {
 	abort(): this {
 		if (this._instance) {
 			this._instance.abort()
+			this._isRecording = false
 		}
 
 		return this

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -155,19 +155,14 @@ describe('Vocal', () => {
 			expect(wrapper.isRecording).toBe(false)
 		})
 
-		it('returns false after stop', async () => {
+		it.each([
+			['stop', (w: Vocal) => w.stop()],
+			['abort', (w: Vocal) => w.abort()],
+		] as const)('returns false after %s', async (_, action) => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
 			const wrapper = new Vocal()
 			await wrapper.start()
-			wrapper.stop()
-			expect(wrapper.isRecording).toBe(false)
-		})
-
-		it('returns false after abort', async () => {
-			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal()
-			await wrapper.start()
-			wrapper.abort()
+			action(wrapper)
 			expect(wrapper.isRecording).toBe(false)
 		})
 

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -126,6 +126,67 @@ describe('Vocal', () => {
 		})
 	})
 
+	describe('isRecording', () => {
+		it('returns false by default', () => {
+			const wrapper = new Vocal()
+			expect(wrapper.isRecording).toBe(false)
+		})
+
+		it('returns true after a successful start', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+			const wrapper = new Vocal()
+			await wrapper.start()
+			expect(wrapper.isRecording).toBe(true)
+		})
+
+		it('remains false when start fails due to null stream', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockNull)
+			const wrapper = new Vocal()
+			wrapper.addEventListener(Vocal.eventTypes.ERROR, vi.fn())
+			await wrapper.start()
+			expect(wrapper.isRecording).toBe(false)
+		})
+
+		it('remains false when start fails due to getUserMediaStream throwing', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockRejectedValueOnce(new Error('mic denied'))
+			const wrapper = new Vocal()
+			wrapper.addEventListener(Vocal.eventTypes.ERROR, vi.fn())
+			await wrapper.start()
+			expect(wrapper.isRecording).toBe(false)
+		})
+
+		it('returns false after stop', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+			const wrapper = new Vocal()
+			await wrapper.start()
+			wrapper.stop()
+			expect(wrapper.isRecording).toBe(false)
+		})
+
+		it('returns false after abort', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+			const wrapper = new Vocal()
+			await wrapper.start()
+			wrapper.abort()
+			expect(wrapper.isRecording).toBe(false)
+		})
+
+		it('returns false when end event fires', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+			const wrapper = new Vocal()
+			await wrapper.start()
+			mockInstance(wrapper)
+				.addEventListener.mock.calls.filter(([type]: string[]) => type === 'end')
+				.forEach(([, handler]: [string, EventListener]) => handler(new Event('end')))
+			expect(wrapper.isRecording).toBe(false)
+		})
+
+		it('throws when setting isRecording directly', () => {
+			const wrapper = new Vocal()
+			expect(() => (wrapper.isRecording = true)).toThrow()
+		})
+	})
+
 	describe('start', () => {
 		it('calls instance.start when getUserMediaStream returns a stream', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)


### PR DESCRIPTION
## Summary

Adds a `isRecording` boolean getter to `Vocal` that reflects whether speech recognition is currently active. Eliminates the need for consumers to maintain their own recording state flag alongside `start()`/`stop()` calls.

## Changes

- `src/Vocal.ts`: add `_isRecording` private field, `isRecording` getter/setter guard, internal `end` event listener in constructor, set flag in `start()`/`stop()`/`abort()`
- `src/__tests__/Vocal.test.ts`: 9 new tests covering all state transitions and the write guard
- `README.md`: add `## Getters` section documenting `isSupported`, `instance`, and `isRecording`

## Test plan

- [x] `yarn test:ci` — 47/47 pass, 100% coverage
- [x] `yarn build` — passes
- [x] `yarn typecheck` — zero TypeScript errors
- [x] `yarn lint` — no errors

Closes #27