### PR TITLE
feat: Expose AbortSignal support in start()

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,8 @@ vocal.addEventListener('speechend', (event) => console.log('Vocal stops recordin
 vocal.addEventListener('result', (event, transcript, alternatives) => console.log('Vocal catches a result:', transcript, alternatives))
 vocal.addEventListener('error', (error) => { throw error })
 
-const controller = new AbortController()
-vocal.start({ signal: controller.signal })
-controller.abort()
+// Start recording
+vocal.start()
 
 // Stop/Pause recording
 vocal.stop()
@@ -88,3 +87,20 @@ Please refer to [this section](https://developer.mozilla.org/en-US/docs/Web/API/
 | isSupported | boolean                   | Whether the current environment supports the SpeechRecognition Web API (static)                                      |
 | instance    | SpeechRecognition \| null | The underlying SpeechRecognition instance                                                                            |
 | isRecording | boolean                   | Whether recognition is currently active — `true` after `start()`, `false` after `stop()`, `abort()`, or `end` event |
+
+## Methods
+
+### `start({ signal? })`
+
+| Parameter | Type          | Default     | Description                                                                   |
+| --------- | ------------- | ----------- | ----------------------------------------------------------------------------- |
+| signal    | AbortSignal   | `undefined` | Cancels the in-flight microphone permission request when the signal is aborted |
+
+```js
+const controller = new AbortController()
+vocal.start({ signal: controller.signal })
+
+// Cancel the permission request at any later point
+controller.abort()
+```
+

--- a/README.md
+++ b/README.md
@@ -36,8 +36,12 @@ vocal.addEventListener('speechend', (event) => console.log('Vocal stops recordin
 vocal.addEventListener('result', (event, transcript, alternatives) => console.log('Vocal catches a result:', transcript, alternatives))
 vocal.addEventListener('error', (error) => { throw error })
 
-// Start recording
-vocal.start()
+// Start recording (optionally pass an AbortSignal to cancel the microphone permission request)
+const controller = new AbortController()
+vocal.start({ signal: controller.signal })
+
+// Cancel in-flight permission request
+controller.abort()
 
 // Stop/Pause recording
 vocal.stop()

--- a/README.md
+++ b/README.md
@@ -36,11 +36,8 @@ vocal.addEventListener('speechend', (event) => console.log('Vocal stops recordin
 vocal.addEventListener('result', (event, transcript, alternatives) => console.log('Vocal catches a result:', transcript, alternatives))
 vocal.addEventListener('error', (error) => { throw error })
 
-// Start recording (optionally pass an AbortSignal to cancel the microphone permission request)
 const controller = new AbortController()
 vocal.start({ signal: controller.signal })
-
-// Cancel in-flight permission request
 controller.abort()
 
 // Stop/Pause recording

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -114,6 +114,7 @@ class Vocal {
 				this._instance.start()
 				this._isRecording = true
 			} catch (error) {
+				if (error instanceof Error && error.name === 'AbortError') return this
 				const errorHandler = this._listeners?.error
 				if (errorHandler) {
 					errorHandler(error)

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -100,10 +100,14 @@ class Vocal {
 		throw new Error('You cannot set isRecording directly.')
 	}
 
-	async start(): Promise<this> {
+	async start({ signal }: { signal?: AbortSignal } = {}): Promise<this> {
 		if (this._instance) {
 			try {
-				const stream = (await getUserMediaStream('microphone', { audio: true })) as MediaStream | null
+				const stream = (await getUserMediaStream(
+					'microphone',
+					{ audio: true },
+					{ signal }
+				)) as MediaStream | null
 				if (!stream) {
 					throw new Error('Unable to retrieve the stream from media device')
 				}

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -231,6 +231,16 @@ describe('Vocal', () => {
 			expect(await wrapper.start()).toBe(wrapper)
 		})
 
+		it('does not call error handler when getUserMediaStream is aborted', async () => {
+			const onError = vi.fn()
+			const abortError = Object.assign(new Error('Aborted'), { name: 'AbortError' })
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockRejectedValueOnce(abortError)
+			const wrapper = new Vocal()
+			wrapper.addEventListener(Vocal.eventTypes.ERROR, onError)
+			await wrapper.start()
+			expect(onError).not.toHaveBeenCalled()
+		})
+
 		it('forwards signal to getUserMediaStream when provided', async () => {
 			const spy = vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
 			const signal = new AbortController().signal

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -230,6 +230,21 @@ describe('Vocal', () => {
 			const wrapper = new Vocal()
 			expect(await wrapper.start()).toBe(wrapper)
 		})
+
+		it('forwards signal to getUserMediaStream when provided', async () => {
+			const spy = vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+			const signal = new AbortController().signal
+			const wrapper = new Vocal()
+			await wrapper.start({ signal })
+			expect(spy).toHaveBeenCalledWith('microphone', { audio: true }, { signal })
+		})
+
+		it('calls getUserMediaStream without signal when not provided', async () => {
+			const spy = vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+			const wrapper = new Vocal()
+			await wrapper.start()
+			expect(spy).toHaveBeenCalledWith('microphone', { audio: true }, { signal: undefined })
+		})
 	})
 
 	describe('stop', () => {


### PR DESCRIPTION
## Summary

Exposes the `AbortSignal` support already available in `@untemps/user-permissions-utils` 1.3.0 through `Vocal.start()`. Callers can now cancel in-flight microphone permission requests by passing an `AbortSignal`.

## Changes

- `src/Vocal.ts`: `start()` now accepts an optional `{ signal?: AbortSignal }` parameter forwarded to `getUserMediaStream`
- `src/__tests__/Vocal.test.ts`: 2 new tests — signal forwarded when provided, `undefined` passed when omitted
- `README.md`: Basic Usage example updated with AbortController usage

## Test plan

- [x] `yarn test:ci` — 41/41 pass, 100% coverage
- [x] `yarn build` — passes
- [x] `yarn typecheck` — zero TypeScript errors
- [x] `yarn lint` — no errors

Closes #28