### PR TITLE
refactor!: Select best RESULT transcript by confidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ const vocal = new Vocal(options)
 // Subscribe to Vocal instance events (see below for all available events)
 vocal.addEventListener('speechstart', (event) => console.log('Vocal starts recording'))
 vocal.addEventListener('speechend', (event) => console.log('Vocal stops recording'))
-vocal.addEventListener('result', (event, transcript, alternatives) => console.log('Vocal catches a result:', transcript, alternatives))
+vocal.addEventListener('result', (event, bestAlternative, alternatives) => console.log('Vocal catches a result:', bestAlternative, alternatives))
 vocal.addEventListener('error', (error) => { throw error })
 
 // Start recording
@@ -73,7 +73,7 @@ Please refer to [this section](https://developer.mozilla.org/en-US/docs/Web/API/
 | end         | Fired when the recognition service has disconnected                                       |
 | error       | Fired when a recognition error occurs                                                     |
 | nomatch     | Fired when the recognition service returns a final result with no significant recognition |
-| result      | Fired when the recognition service returns a result — callback receives `(event, transcript: string, alternatives: string[])` where `transcript === alternatives[0]` |
+| result      | Fired when the recognition service returns a result — callback receives `(event, bestAlternative: string, alternatives: string[])` where `bestAlternative` is the alternative with the highest confidence |
 | soundend    | Fired when any sound — recognisable or not — has stopped being detected                   |
 | soundstart  | Fired when any sound — recognisable or not — has been detected                            |
 | speechend   | Fired when speech recognized by the recognition service has stopped being detected        |

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -154,8 +154,14 @@ class Vocal {
 				if (eventType === Vocal.eventTypes.RESULT) {
 					const speechEvent = event as SpeechRecognitionEvent
 					if (speechEvent.results?.length > 0) {
-						const alternatives = Array.from(speechEvent.results[0], (alt) => alt.transcript)
-						additionalArgs.push(alternatives[0], alternatives)
+						const alternatives = Array.from(speechEvent.results[0])
+						const bestAlternative = alternatives.reduce((a, b) =>
+							(b.confidence ?? 0) > (a.confidence ?? 0) ? b : a
+						)
+						additionalArgs.push(
+							bestAlternative.transcript,
+							alternatives.map((a) => a.transcript)
+						)
 					}
 				}
 

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -304,7 +304,7 @@ describe('Vocal', () => {
 			expect(onStart).toHaveBeenCalled()
 		})
 
-		it('passes transcript and alternatives array for RESULT events', () => {
+		it('passes best transcript and alternatives array for RESULT events', () => {
 			const onResult = vi.fn()
 			const wrapper = new Vocal()
 			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
@@ -318,6 +318,42 @@ describe('Vocal', () => {
 			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
 			mockInstance(wrapper).say('hello', ['hello', 'helo', 'hell'])
 			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'hello', ['hello', 'helo', 'hell'])
+		})
+
+		it('falls back to first alternative when confidence is unavailable', () => {
+			const onResult = vi.fn()
+			const wrapper = new Vocal()
+			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
+			const [, handler] = (mockInstance(wrapper).addEventListener.mock.calls as string[][]).find(
+				([type]) => type === Vocal.eventTypes.RESULT
+			)!
+			const event = Object.assign(new Event(Vocal.eventTypes.RESULT), {
+				resultIndex: 0,
+				results: [[{ transcript: 'hello' }, { transcript: 'helo' }, { transcript: 'hell' }]],
+			})
+			;(handler as unknown as (e: Event) => void)(event)
+			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'hello', ['hello', 'helo', 'hell'])
+		})
+
+		it('selects the alternative with highest confidence as best transcript', () => {
+			const onResult = vi.fn()
+			const wrapper = new Vocal()
+			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
+			const [, handler] = (mockInstance(wrapper).addEventListener.mock.calls as string[][]).find(
+				([type]) => type === Vocal.eventTypes.RESULT
+			)!
+			const event = Object.assign(new Event(Vocal.eventTypes.RESULT), {
+				resultIndex: 0,
+				results: [
+					[
+						{ transcript: 'hello', confidence: 0.7 },
+						{ transcript: 'helo', confidence: 0.9 },
+						{ transcript: 'hell', confidence: 0.5 },
+					],
+				],
+			})
+			;(handler as unknown as (e: Event) => void)(event)
+			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'helo', ['hello', 'helo', 'hell'])
 		})
 
 		it('does not pass transcript for RESULT events with empty results', () => {


### PR DESCRIPTION
## Summary

Changes the RESULT callback to select the best transcript by **confidence score** rather than by array position. The signature stays at three arguments — `(event, best, alternatives)` — but `best` is now explicitly the alternative with the highest `confidence` value. Browsers already sort alternatives by confidence, so this is a semantic clarification with no practical behaviour change for most callers.

## Changes

- \`src/Vocal.ts\`: replace \`alternatives[0]\` selection with \`reduce\` over \`confidence\` (fallback to \`0\` if absent)
- \`src/__tests__/Vocal.test.ts\`: update existing RESULT assertions + add explicit confidence-based selection test
- \`README.md\`: update Basic Usage example and Events table — \`transcript\` → \`best\`

## ⚠️ Breaking changes

- **RESULT callback**: second argument renamed conceptually from \`transcript\` to \`best\` (the alternative with highest confidence). Value is identical to the previous \`transcript\` for browsers that sort alternatives by confidence (all major browsers).
- Migration: rename the parameter; no logic change needed unless you were relying on array order differing from confidence order.

## Test plan

- [x] \`yarn test:ci\` — 51/51 pass, 100% coverage
- [x] \`yarn build\` — passes
- [x] \`yarn typecheck\` — zero TypeScript errors
- [x] \`yarn lint\` — no errors

Closes #36