### PR TITLE
fix: Use resultIndex to select current result in continuous mode

### DIFF
--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -150,8 +150,8 @@ class Vocal {
 				const additionalArgs: unknown[] = []
 				if (eventType === Vocal.eventTypes.RESULT) {
 					const speechEvent = event as SpeechRecognitionEvent
-					if (speechEvent.results?.length > 0) {
-						const alternatives = Array.from(speechEvent.results[0])
+					if (speechEvent.results?.length > 0 && speechEvent.resultIndex < speechEvent.results.length) {
+						const alternatives = Array.from(speechEvent.results[speechEvent.resultIndex])
 						const bestAlternative = alternatives.reduce((a, b) =>
 							(b.confidence ?? 0) > (a.confidence ?? 0) ? b : a
 						)

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -327,6 +327,40 @@ describe('Vocal', () => {
 			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'helo', ['hello', 'helo', 'hell'])
 		})
 
+		it('uses resultIndex to select the current result in continuous mode', () => {
+			const onResult = vi.fn()
+			const wrapper = new Vocal()
+			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
+			const [, handler] = (mockInstance(wrapper).addEventListener.mock.calls as string[][]).find(
+				([type]) => type === Vocal.eventTypes.RESULT
+			)!
+			const event = Object.assign(new Event(Vocal.eventTypes.RESULT), {
+				resultIndex: 1,
+				results: [
+					[{ transcript: 'first utterance', confidence: 0.9 }],
+					[{ transcript: 'second utterance', confidence: 0.8 }],
+				],
+			})
+			;(handler as unknown as (e: Event) => void)(event)
+			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'second utterance', ['second utterance'])
+		})
+
+		it('does not pass transcript when resultIndex is out of bounds', () => {
+			const onResult = vi.fn()
+			const wrapper = new Vocal()
+			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
+			const [, handler] = (mockInstance(wrapper).addEventListener.mock.calls as string[][]).find(
+				([type]) => type === Vocal.eventTypes.RESULT
+			)!
+			const event = Object.assign(new Event(Vocal.eventTypes.RESULT), {
+				resultIndex: 5,
+				results: [[{ transcript: 'hello', confidence: 0.9 }]],
+			})
+			;(handler as unknown as (e: Event) => void)(event)
+			expect(onResult).toHaveBeenCalledTimes(1)
+			expect(onResult.mock.calls[0]).toHaveLength(1)
+		})
+
 		it('does not pass transcript for RESULT events with empty results', () => {
 			const onResult = vi.fn()
 			const wrapper = new Vocal()


### PR DESCRIPTION
## Summary

Fixes a bug where `continuous: true` mode always delivered the first accumulated recognition result to the callback. The handler now uses `speechEvent.resultIndex` to access the correct current result.

## Changes

- `src/Vocal.ts`: `results[0]` → `results[speechEvent.resultIndex]` in the RESULT event handler
- `src/__tests__/Vocal.test.ts`: new test verifying that `resultIndex: 1` with two accumulated results correctly selects the second one

## Test plan

- [x] `yarn test:ci` — 50/50 pass, 100% coverage
- [x] `yarn build` — passes
- [x] `yarn typecheck` — zero TypeScript errors
- [x] `yarn lint` — no errors

Closes #47