### PR TITLE
fix: Return false from isSupported in non-browser environments

### DIFF
--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -196,6 +196,7 @@ class Vocal {
 	}
 
 	static _resolveSpeechRecognition(): typeof SpeechRecognition | undefined {
+		if (typeof window === 'undefined') return undefined
 		return (
 			window.SpeechRecognition ??
 			window.webkitSpeechRecognition ??

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -54,6 +54,22 @@ describe('Vocal', () => {
 				expect(Vocal.isSupported).toBe(false)
 			})
 		})
+
+		describe('when window is not defined (SSR)', () => {
+			let originalWindow: typeof globalThis.window
+			beforeEach(() => {
+				originalWindow = globalThis.window
+				delete (globalThis as unknown as Record<string, unknown>).window
+			})
+			afterEach(() => {
+				globalThis.window = originalWindow
+			})
+
+			it('returns false without throwing', () => {
+				expect(() => Vocal.isSupported).not.toThrow()
+				expect(Vocal.isSupported).toBe(false)
+			})
+		})
 	})
 
 	describe('constructor', () => {


### PR DESCRIPTION
## Summary

`Vocal.isSupported` was throwing a `ReferenceError` in SSR and non-browser environments (Node.js, Deno, Next.js, SvelteKit) because `_resolveSpeechRecognition()` accessed `window` directly without a guard. After this fix, `isSupported` returns `false` gracefully, enabling it to be used as a safe guard before instantiation.

## Changes

- `src/Vocal.ts`: add `if (typeof window === 'undefined') return undefined` to `_resolveSpeechRecognition()`. The guard in `_resolveSpeechGrammarList()` is intentionally omitted — it is only called from the constructor after `_resolveSpeechRecognition()` has already returned a non-null value, making a window check there unreachable dead code.
- `src/__tests__/Vocal.test.ts`: add SSR test that temporarily removes `globalThis.window` and verifies `isSupported` returns `false` without throwing.

## Test plan

- [x] `yarn test:ci` — 52/52 pass, 100% coverage
- [x] `yarn build` — passes
- [x] `yarn typecheck` — zero TypeScript errors
- [x] `yarn lint` — no errors

Closes #48