### PR TITLE
refactor: Make _resolveSpeech* methods private static

### DIFF
--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -195,7 +195,7 @@ class Vocal {
 		return Object.values(Vocal.eventTypes).includes(eventType as EventType)
 	}
 
-	static _resolveSpeechRecognition(): typeof SpeechRecognition | undefined {
+	private static _resolveSpeechRecognition(): typeof SpeechRecognition | undefined {
 		if (typeof window === 'undefined') return undefined
 		return (
 			window.SpeechRecognition ??
@@ -205,7 +205,7 @@ class Vocal {
 		)
 	}
 
-	static _resolveSpeechGrammarList(): typeof SpeechGrammarList | undefined {
+	private static _resolveSpeechGrammarList(): typeof SpeechGrammarList | undefined {
 		return (
 			window.SpeechGrammarList ??
 			window.webkitSpeechGrammarList ??


### PR DESCRIPTION
## Summary

`_resolveSpeechRecognition()` and `_resolveSpeechGrammarList()` were declared `static` without `private`, making them part of the public TypeScript API surface and appearing in generated `.d.ts` files. Adding `private` removes them from the public contract.

## Changes

- `src/Vocal.ts`: `static _resolveSpeechRecognition()` → `private static _resolveSpeechRecognition()`, same for `_resolveSpeechGrammarList()`

## Test plan

- [x] `yarn test:ci` — 52/52 pass, 100% coverage
- [x] `yarn typecheck` — zero errors (internal calls within the class are unaffected by `private`)
- [x] `yarn lint` — no errors

Closes #49