### PR TITLE
fix: Declare missing Web Speech API types in types.d.ts

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,28 @@
 // Web Speech API types not yet in standard lib.dom.d.ts
+
+declare interface SpeechRecognitionAlternative {
+	readonly transcript: string
+	readonly confidence: number
+}
+
+declare interface SpeechRecognitionResult {
+	readonly length: number
+	readonly isFinal: boolean
+	item(index: number): SpeechRecognitionAlternative
+	[index: number]: SpeechRecognitionAlternative
+}
+
+declare interface SpeechRecognitionResultList {
+	readonly length: number
+	item(index: number): SpeechRecognitionResult
+	[index: number]: SpeechRecognitionResult
+}
+
+declare interface SpeechRecognitionEvent extends Event {
+	readonly resultIndex: number
+	readonly results: SpeechRecognitionResultList
+}
+
 declare interface SpeechRecognition extends EventTarget {
 	continuous: boolean
 	grammars: SpeechGrammarList | null


### PR DESCRIPTION
## Summary

Adds the four missing Web Speech API type declarations to `src/types.d.ts`: `SpeechRecognitionAlternative`, `SpeechRecognitionResult`, `SpeechRecognitionResultList`, and `SpeechRecognitionEvent`. These were used internally via unsafe `as` casts; they are now properly declared, making the internal code type-safe and giving TypeScript consumers the types they need to annotate their callbacks.

## Changes

- `src/types.d.ts`: add `SpeechRecognitionAlternative` (`transcript`, `confidence`), `SpeechRecognitionResult` (array-like, `isFinal`), `SpeechRecognitionResultList` (array-like), `SpeechRecognitionEvent` (`resultIndex`, `results`)

## Test plan

- [x] `yarn typecheck` — zero errors; `as SpeechRecognitionEvent` cast and `alt.transcript`/`alt.confidence` access are now type-safe
- [x] `yarn test:ci` — 52/52 pass, 100% coverage
- [x] `yarn build` — passes
- [x] `yarn lint` — no errors

Closes #50