### PR TITLE
fix: Remove internal end listener on cleanup

### DIFF
--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -54,6 +54,9 @@ class Vocal {
 	private _instance: SpeechRecognition | null = null
 	private _listeners: Record<string, EventHandler> | null = null
 	private _isRecording: boolean = false
+	private _onEnd: () => void = () => {
+		this._isRecording = false
+	}
 
 	constructor(options?: VocalOptions) {
 		const SpeechRecognition = Vocal._resolveSpeechRecognition()
@@ -79,9 +82,7 @@ class Vocal {
 			instance.grammars = grammars
 		}
 
-		this._instance.addEventListener('end', () => {
-			this._isRecording = false
-		})
+		this._instance.addEventListener('end', this._onEnd)
 	}
 
 	get instance(): SpeechRecognition | null {
@@ -186,6 +187,7 @@ class Vocal {
 		this.stop()
 
 		Object.keys(this._listeners!).forEach((key) => this.removeEventListener(key))
+		this._instance?.removeEventListener('end', this._onEnd)
 		this._instance = null
 
 		return this

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -457,7 +457,12 @@ describe('Vocal', () => {
 			wrapper.addEventListener(Vocal.eventTypes.START, vi.fn())
 			wrapper.addEventListener(Vocal.eventTypes.END, vi.fn())
 			wrapper.cleanup()
-			expect(instance.removeEventListener).toHaveBeenCalledTimes(2)
+			expect(instance.removeEventListener).toHaveBeenCalledTimes(3)
+		})
+
+		it('removes the internal end listener on cleanup', () => {
+			wrapper.cleanup()
+			expect(instance.removeEventListener).toHaveBeenCalledWith('end', expect.any(Function))
 		})
 
 		it('nulls the instance', () => {


### PR DESCRIPTION
## Summary

The anonymous `end` listener added to `_instance` in the constructor was not removed by `cleanup()` because it was not tracked in `_listeners`. The listener closure kept a reference to `this`, preventing full garbage collection of the `Vocal` wrapper if external code retained the raw `SpeechRecognition` instance.

## Changes

- `src/Vocal.ts`: extract the `end` handler to a private field `_onEnd`, register it by reference in the constructor, and explicitly remove it in `cleanup()` before nulling `_instance`
- `src/__tests__/Vocal.test.ts`: update `removeEventListener` call count from 2 to 3 in the cleanup test; add dedicated test verifying the internal `end` listener is removed

## Test plan

- [x] `yarn test:ci` — 53/53 pass, 100% coverage
- [x] `yarn build` — passes
- [x] `yarn typecheck` — zero errors
- [x] `yarn lint` — no errors

Closes #51