### PR TITLE
chore(ci): Add lint and typecheck steps to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,8 @@ jobs:
           node-version: '24'
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
+      - run: yarn lint
+      - run: yarn typecheck
       - run: yarn test:ci
       - run: yarn build
       - run: npx semantic-release


### PR DESCRIPTION
## Summary

The publish workflow only ran `yarn test:ci` and `yarn build`, leaving lint errors and TypeScript type errors undetected in CI. Both checks are now added before the build step.

## Changes

- `.github/workflows/publish.yml`: add `yarn lint` and `yarn typecheck` between `yarn test:ci` and `yarn build`

## Test plan

- [x] Workflow updated — lint and typecheck run before build on every push to `main` or `beta`

Closes #53