### PR TITLE
feat: Add typed event handler overloads to addEventListener

### DIFF
--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -14,7 +14,21 @@ export interface VocalOptions {
 
 export type EventType = (typeof Vocal.eventTypes)[keyof typeof Vocal.eventTypes]
 
-type EventHandler = (event: Event | unknown, ...args: unknown[]) => void
+export type ResultEventHandler = (
+	event: SpeechRecognitionEvent,
+	bestAlternative: string,
+	alternatives: string[]
+) => void
+export type ErrorEventHandler = (event: SpeechRecognitionErrorEvent) => void
+export type GenericEventHandler = (event: Event) => void
+
+export type EventHandlerFor<T extends EventType> = T extends 'result'
+	? ResultEventHandler
+	: T extends 'error'
+		? ErrorEventHandler
+		: GenericEventHandler
+
+type EventHandler = (...args: unknown[]) => void
 
 class Vocal {
 	static defaultOptions: Required<VocalOptions> = {
@@ -141,13 +155,14 @@ class Vocal {
 		return this
 	}
 
+	addEventListener<T extends EventType>(eventType: T, callback: EventHandlerFor<T>): this
 	addEventListener(eventType: string, callback: EventHandler): this {
 		if (!this._includesEventType(eventType)) {
 			throw new Error(this._unknownEventTypeMessage(eventType))
 		}
 		if (this._instance && this._listeners) {
 			if (this._listeners[eventType]) {
-				this.removeEventListener(eventType)
+				this.removeEventListener(eventType as EventType)
 			}
 
 			const handler: EventHandler = (event) => {
@@ -166,7 +181,7 @@ class Vocal {
 					}
 				}
 
-				callback.apply(this, [event, ...additionalArgs])
+				;(callback as EventHandler).call(this, event, ...additionalArgs)
 			}
 			this._instance.addEventListener(eventType, handler as EventListener)
 
@@ -176,6 +191,7 @@ class Vocal {
 		return this
 	}
 
+	removeEventListener(eventType: EventType): this
 	removeEventListener(eventType: string): this {
 		if (!this._includesEventType(eventType)) {
 			throw new Error(this._unknownEventTypeMessage(eventType))
@@ -192,7 +208,7 @@ class Vocal {
 	cleanup(): this {
 		this.stop()
 
-		Object.keys(this._listeners!).forEach((key) => this.removeEventListener(key))
+		Object.keys(this._listeners!).forEach((key) => this.removeEventListener(key as EventType))
 		this._instance?.removeEventListener('end', this._onEnd)
 		this._instance = null
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,9 @@
 export { default as Vocal } from './Vocal'
-export type { VocalOptions, EventType } from './Vocal'
+export type {
+	VocalOptions,
+	EventType,
+	ResultEventHandler,
+	ErrorEventHandler,
+	GenericEventHandler,
+	EventHandlerFor,
+} from './Vocal'

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -23,6 +23,11 @@ declare interface SpeechRecognitionEvent extends Event {
 	readonly results: SpeechRecognitionResultList
 }
 
+declare interface SpeechRecognitionErrorEvent extends Event {
+	readonly error: string
+	readonly message: string
+}
+
 declare interface SpeechRecognition extends EventTarget {
 	continuous: boolean
 	grammars: SpeechGrammarList | null


### PR DESCRIPTION
## Summary

Adds typed callback signatures to `addEventListener` so TypeScript consumers get proper type inference based on the event type string. Replaces the opaque `(event: Event | unknown, ...args: unknown[]) => void` with specific handler types per event.

## Approach

Uses a generic overload with a conditional type `EventHandlerFor<T>` rather than multiple method overloads, avoiding contravariance issues with TypeScript's strict function type checking:

```typescript
addEventListener<T extends EventType>(eventType: T, callback: EventHandlerFor<T>): this
```

where:
- `'result'` → `ResultEventHandler` — `(event: SpeechRecognitionEvent, bestAlternative: string, alternatives: string[]) => void`
- `'error'` → `ErrorEventHandler` — `(event: SpeechRecognitionErrorEvent) => void`
- anything else → `GenericEventHandler` — `(event: Event) => void`

## Changes

- `src/types.d.ts`: add `SpeechRecognitionErrorEvent` declaration
- `src/Vocal.ts`: add `ResultEventHandler`, `ErrorEventHandler`, `GenericEventHandler`, `EventHandlerFor<T>` exported types; generic overload on `addEventListener`; `removeEventListener` overload typed to `EventType`
- `src/index.ts`: export the four new types

## Test plan

- [x] `yarn test:ci` — 55/55 pass, 100% coverage
- [x] `yarn typecheck` — zero errors
- [x] `yarn build` — passes; new types visible in generated `.d.ts`
- [x] `yarn lint` — no errors

Closes #54