### PR TITLE
chore(test): Add confidence simulation to say() mock

### DIFF
--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -6,8 +6,10 @@ type MockFn = {
 	mock: { calls: unknown[][] }
 }
 
+type SayAlternative = string | { transcript: string; confidence: number }
+
 interface MockInstance {
-	say: MockFn
+	say: ((sentence: string, alternatives?: SayAlternative[]) => void) & { mock: { calls: unknown[][] } }
 	addEventListener: MockFn
 	removeEventListener: MockFn
 	start: MockFn
@@ -326,20 +328,11 @@ describe('Vocal', () => {
 			const onResult = vi.fn()
 			const wrapper = new Vocal()
 			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
-			const [, handler] = (mockInstance(wrapper).addEventListener.mock.calls as string[][]).find(
-				([type]) => type === Vocal.eventTypes.RESULT
-			)!
-			const event = Object.assign(new Event(Vocal.eventTypes.RESULT), {
-				resultIndex: 0,
-				results: [
-					[
-						{ transcript: 'hello', confidence: 0.7 },
-						{ transcript: 'helo', confidence: 0.9 },
-						{ transcript: 'hell', confidence: 0.5 },
-					],
-				],
-			})
-			;(handler as unknown as (e: Event) => void)(event)
+			mockInstance(wrapper).say('helo', [
+				{ transcript: 'hello', confidence: 0.7 },
+				{ transcript: 'helo', confidence: 0.9 },
+				{ transcript: 'hell', confidence: 0.5 },
+			])
 			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'helo', ['hello', 'helo', 'hell'])
 		})
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -20,6 +20,8 @@ interface MockMediaDevices {
 	getUserMedia: Mock
 }
 
+type SayAlternative = string | { transcript: string; confidence: number }
+
 interface MockSpeechRecognitionInstance {
 	addEventListener: Mock
 	removeEventListener: Mock
@@ -27,7 +29,7 @@ interface MockSpeechRecognitionInstance {
 	start: Mock
 	stop: Mock
 	abort: Mock
-	say: Mock
+	say: Mock<[sentence: string, alternatives?: SayAlternative[]], void>
 }
 
 declare global {
@@ -90,16 +92,16 @@ global.SpeechRecognition = vi.fn(function () {
 		abort: vi.fn(function () {
 			handlers.end?.()
 		}),
-		say: vi.fn(function (sentence: string, alternatives?: string[]) {
+		say: vi.fn(function (sentence: string, alternatives?: (string | { transcript: string; confidence: number })[]) {
 			handlers.speechstart?.()
 
 			const alts = alternatives ?? [sentence]
 			const resultEvent = new Event('result') as Event & {
 				resultIndex: number
-				results: { transcript: string }[][]
+				results: { transcript: string; confidence: number }[][]
 			}
 			resultEvent.resultIndex = 0
-			resultEvent.results = [alts.map((t) => ({ transcript: t }))]
+			resultEvent.results = [alts.map((t) => (typeof t === 'string' ? { transcript: t, confidence: 0 } : t))]
 			if (sentence) {
 				handlers.result?.(resultEvent)
 			} else {


### PR DESCRIPTION
## Summary

Extends the `say()` mock in `vitest.setup.ts` to accept `{ transcript, confidence }` objects alongside plain strings, enabling confidence-based tests to use the same helper as the rest of the suite. The "selects highest confidence" test is migrated from manual event construction to `say()`.

## Changes

- `vitest.setup.ts`: `say()` now accepts `(string | { transcript: string; confidence: number })[]` — plain strings default to `confidence: 0`
- `src/__tests__/Vocal.test.ts`: "selects the alternative with highest confidence" migrated to `say()` with object alternatives

## Why other confidence tests stay manual

- "falls back to first alternative when confidence is unavailable" — tests `undefined` confidence, which `say()` cannot produce (it always provides a number)
- "uses resultIndex to select the current result" — requires `resultIndex: 1` with multiple accumulated results; `say()` always sets `resultIndex: 0`
- "does not pass transcript when resultIndex is out of bounds" — requires `resultIndex: 5`; not expressible via `say()`

## Test plan

- [x] `yarn test:ci` — 55/55 pass, 100% coverage
- [x] `yarn typecheck` — zero errors
- [x] `yarn lint` — no errors

Closes #55