### PR TITLE
chore(tooling): Include root config files in prettier script

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,6 +2,6 @@ export default {
 	extends: ['@commitlint/config-conventional'],
 	rules: {
 		'subject-case': [2, 'always', ['sentence-case']],
-		'scope-case': [2, 'always', ['lower-case', 'upper-case']]
-	}
+		'scope-case': [2, 'always', ['lower-case', 'upper-case']],
+	},
 }

--- a/package.json
+++ b/package.json
@@ -115,6 +115,6 @@
 		"typecheck": "tsc --noEmit",
 		"lint": "eslint src/ vitest.setup.ts",
 		"prepare": "husky",
-		"prettier": "prettier \"src/**/*.{ts,js}\" vitest.setup.ts --ignore-path ./.prettierignore --write"
+		"prettier": "prettier \"src/**/*.{ts,js}\" vitest.setup.ts \"*.{js,ts}\" --ignore-path ./.prettierignore --write"
 	}
 }


### PR DESCRIPTION
## Summary

Expands the prettier script to cover root-level config files (`vite.config.js`, `eslint.config.js`, `commitlint.config.js`), which were previously excluded and could drift in formatting. `commitlint.config.js` was reformatted immediately (trailing commas added per `.prettierrc` `trailingComma: "es5"`).

## Changes

- `package.json`: `prettier` script adds `"*.{js,ts}"` glob
- `commitlint.config.js`: trailing commas applied by prettier

## Test plan

- [x] `yarn prettier` — all 8 files processed, all pass
- [x] `yarn test:ci` — 55/55 pass, 100% coverage
- [x] `yarn typecheck` — zero errors

Closes #56