### PR TITLE
docs: Fix missing blank line between Options table and Events heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Please refer to [this section](https://developer.mozilla.org/en-US/docs/Web/API/
 | continuous       | boolean           | false      | Whether continuous results are returned for each recognition, or only a single result                             |
 | interimResults   | boolean           | false      | Whether interim results should be returned or not. Interim results are results that are not yet final             |
 | maxAlternatives  | number            | 1          | Maximum number of SpeechRecognitionAlternatives provided per result                                               |
+
 ## Events
 
 Events described below are those from the `SpeechRecognition` Web API.  


### PR DESCRIPTION
## Summary

Adds the missing blank line between the Options table and the `## Events` heading in `README.md`. Without it, some Markdown parsers fail to recognize the heading as a separate block.

## Changes

- `README.md`: one blank line added between `| maxAlternatives | ... |` and `## Events`

Closes #57