### PR TITLE
feat!: Support multiple listeners per event type in addEventListener

### DIFF
--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -66,7 +66,7 @@ class Vocal {
 	}
 
 	private _instance: SpeechRecognition | null = null
-	private _listeners: Record<string, EventHandler> | null = null
+	private _listeners: Record<string, Array<{ callback: EventHandler; handler: EventHandler }>> | null = null
 	private _isRecording: boolean = false
 	private _onEnd: () => void = () => {
 		this._isRecording = false
@@ -161,10 +161,6 @@ class Vocal {
 			throw new Error(this._unknownEventTypeMessage(eventType))
 		}
 		if (this._instance && this._listeners) {
-			if (this._listeners[eventType]) {
-				this.removeEventListener(eventType as EventType)
-			}
-
 			const handler: EventHandler = (event) => {
 				const additionalArgs: unknown[] = []
 				if (eventType === Vocal.eventTypes.RESULT) {
@@ -185,21 +181,37 @@ class Vocal {
 			}
 			this._instance.addEventListener(eventType, handler as EventListener)
 
-			this._listeners[eventType] = handler
+			if (!this._listeners[eventType]) {
+				this._listeners[eventType] = []
+			}
+			this._listeners[eventType].push({ callback, handler })
 		}
 
 		return this
 	}
 
-	removeEventListener(eventType: EventType): this
-	removeEventListener(eventType: string): this {
+	removeEventListener<T extends EventType>(eventType: T, callback?: EventHandlerFor<T>): this
+	removeEventListener(eventType: string, callback?: EventHandler): this {
 		if (!this._includesEventType(eventType)) {
 			throw new Error(this._unknownEventTypeMessage(eventType))
 		}
-		if (this._instance && this._listeners) {
-			const handler = this._listeners[eventType]
-			this._instance.removeEventListener(eventType, handler as EventListener)
-			delete this._listeners[eventType]
+		const instance = this._instance
+		if (instance && this._listeners && this._listeners[eventType]) {
+			if (callback !== undefined) {
+				const idx = this._listeners[eventType].findIndex((e) => e.callback === callback)
+				if (idx !== -1) {
+					instance.removeEventListener(eventType, this._listeners[eventType][idx].handler as EventListener)
+					this._listeners[eventType].splice(idx, 1)
+					if (this._listeners[eventType].length === 0) {
+						delete this._listeners[eventType]
+					}
+				}
+			} else {
+				this._listeners[eventType].forEach(({ handler }) =>
+					instance.removeEventListener(eventType, handler as EventListener)
+				)
+				delete this._listeners[eventType]
+			}
 		}
 
 		return this

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -383,13 +383,24 @@ describe('Vocal', () => {
 			expect(onResult.mock.calls[0]).toHaveLength(1)
 		})
 
-		it('replaces existing listener when same event type is added twice', () => {
+		it('stacks multiple listeners for the same event type', () => {
 			const onStart1 = vi.fn()
 			const onStart2 = vi.fn()
 			const wrapper = new Vocal()
 			wrapper.addEventListener(Vocal.eventTypes.START, onStart1)
 			wrapper.addEventListener(Vocal.eventTypes.START, onStart2)
-			expect(mockInstance(wrapper).removeEventListener).toHaveBeenCalledTimes(1)
+			mockInstance(wrapper).start()
+			expect(onStart1).toHaveBeenCalled()
+			expect(onStart2).toHaveBeenCalled()
+		})
+
+		it('removes a specific listener by callback reference', () => {
+			const onStart1 = vi.fn()
+			const onStart2 = vi.fn()
+			const wrapper = new Vocal()
+			wrapper.addEventListener(Vocal.eventTypes.START, onStart1)
+			wrapper.addEventListener(Vocal.eventTypes.START, onStart2)
+			wrapper.removeEventListener(Vocal.eventTypes.START, onStart1)
 			mockInstance(wrapper).start()
 			expect(onStart1).not.toHaveBeenCalled()
 			expect(onStart2).toHaveBeenCalled()
@@ -435,6 +446,21 @@ describe('Vocal', () => {
 		it('throws on invalid event types', () => {
 			const wrapper = new Vocal()
 			expect(() => wrapper.removeEventListener('invalid-type')).toThrow('Unknown event type "invalid-type"')
+		})
+
+		it('does nothing when callback was never registered', () => {
+			const wrapper = new Vocal()
+			wrapper.addEventListener(Vocal.eventTypes.START, vi.fn())
+			expect(() => wrapper.removeEventListener(Vocal.eventTypes.START, vi.fn())).not.toThrow()
+		})
+
+		it('cleans up the listener entry when last callback is removed by reference', () => {
+			const onStart = vi.fn()
+			const wrapper = new Vocal()
+			wrapper.addEventListener(Vocal.eventTypes.START, onStart)
+			wrapper.removeEventListener(Vocal.eventTypes.START, onStart)
+			mockInstance(wrapper).start()
+			expect(onStart).not.toHaveBeenCalled()
 		})
 	})
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -76,24 +76,32 @@ global.SpeechGrammarList = vi.fn(function () {
 }) as unknown as typeof SpeechGrammarList
 
 global.SpeechRecognition = vi.fn(function () {
-	const handlers: Record<string, (event?: unknown) => void> = {}
+	const handlers: Record<string, ((event?: unknown) => void)[]> = {}
+
+	const dispatch = (type: string, event?: unknown) => handlers[type]?.forEach((h) => h(event))
+
 	return {
 		addEventListener: vi.fn(function (type: string, callback: (event?: unknown) => void) {
-			handlers[type] = callback
+			if (!handlers[type]) handlers[type] = []
+			handlers[type].push(callback)
 		}),
-		removeEventListener: vi.fn(),
+		removeEventListener: vi.fn(function (type: string, callback: (event?: unknown) => void) {
+			if (handlers[type]) {
+				handlers[type] = handlers[type].filter((h) => h !== callback)
+			}
+		}),
 		dispatchEvent: vi.fn(),
 		start: vi.fn(function () {
-			handlers.start?.()
+			dispatch('start')
 		}),
 		stop: vi.fn(function () {
-			handlers.end?.()
+			dispatch('end')
 		}),
 		abort: vi.fn(function () {
-			handlers.end?.()
+			dispatch('end')
 		}),
 		say: vi.fn(function (sentence: string, alternatives?: (string | { transcript: string; confidence: number })[]) {
-			handlers.speechstart?.()
+			dispatch('speechstart')
 
 			const alts = alternatives ?? [sentence]
 			const resultEvent = new Event('result') as Event & {
@@ -103,11 +111,11 @@ global.SpeechRecognition = vi.fn(function () {
 			resultEvent.resultIndex = 0
 			resultEvent.results = [alts.map((t) => (typeof t === 'string' ? { transcript: t, confidence: 0 } : t))]
 			if (sentence) {
-				handlers.result?.(resultEvent)
+				dispatch('result', resultEvent)
 			} else {
-				handlers.nomatch?.()
+				dispatch('nomatch')
 			}
-			handlers.speechend?.()
+			dispatch('speechend')
 		}),
 	} as MockSpeechRecognitionInstance
 }) as unknown as typeof SpeechRecognition


### PR DESCRIPTION
## Summary

`addEventListener` now stacks callbacks for the same event type instead of replacing the previous one, matching the native browser `EventTarget` behavior. `removeEventListener` gains an optional `callback` argument to remove a specific handler by reference.

## Changes

- `src/Vocal.ts`: `_listeners` changes from `Record<string, EventHandler>` to `Record<string, Array<{ callback, handler }>>`;  `addEventListener` appends; `removeEventListener(eventType)` removes all handlers, `removeEventListener(eventType, callback)` removes one
- `vitest.setup.ts`: mock `handlers` is now `Record<string, fn[]>`, all dispatchers iterate all handlers; `removeEventListener` mock properly filters
- `src/__tests__/Vocal.test.ts`: "replaces existing" → "stacks multiple listeners"; add tests for remove-by-reference and unregistered-callback no-op

## ⚠️ Breaking changes

- **`addEventListener`**: calling with the same event type twice now registers both callbacks instead of replacing the first. Callers who relied on replacement must call `removeEventListener(eventType, oldCallback)` first.
- **`removeEventListener(eventType)`**: now removes ALL handlers for the type (unchanged if only one was registered).

## Test plan

- [x] `yarn test:ci` — 57/57 pass, 100% coverage
- [x] `yarn build` — passes
- [x] `yarn typecheck` — zero errors
- [x] `yarn lint` — no errors

Closes #59