### PR TITLE
chore!: Remove UMD bundle from distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
 	"files": [
 		"dist/index.cjs",
 		"dist/index.es.js",
-		"dist/index.umd.js",
 		"dist/index.d.ts",
 		"CHANGELOG.md"
 	],
@@ -98,10 +97,6 @@
 						{
 							"path": "dist/index.es.js",
 							"label": "ES distribution"
-						},
-						{
-							"path": "dist/index.umd.js",
-							"label": "UMD distribution"
 						}
 					]
 				}

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,9 +6,8 @@ export default defineConfig({
 	build: {
 		lib: {
 			entry: 'src/index.ts',
-			name: 'Vocal',
-			formats: ['es', 'cjs', 'umd'],
-			fileName: (format) => ({ es: 'index.es.js', umd: 'index.umd.js', cjs: 'index.cjs' })[format],
+			formats: ['es', 'cjs'],
+			fileName: (format) => ({ es: 'index.es.js', cjs: 'index.cjs' })[format],
 		},
 		rollupOptions: {
 			external: ['@untemps/user-permissions-utils'],


### PR DESCRIPTION
## Summary

Removes the UMD bundle from the build output. UMD targets global script tag usage and AMD loaders — neither is used by modern bundlers or SSR frameworks. ES and CJS cover all current use cases.

## Changes

- `vite.config.js`: remove `umd` from `formats`, remove `name` field (only needed for UMD global), simplify `fileName` map
- `package.json`: remove `dist/index.umd.js` from `files` and from release assets

## ⚠️ Breaking changes

- **`dist/index.umd.js`** is no longer published. Consumers using `<script>` tags or AMD loaders should use `dist/index.es.js` with a module-aware loader instead.

## Test plan

- [x] `yarn build` — generates only `dist/index.cjs` and `dist/index.es.js`
- [x] `yarn test:ci` — 60/60 pass, 100% coverage
- [x] `yarn lint` — no errors

Closes #63