### PR TITLE
refactor: Clean up _listeners type and document missing public methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,36 @@ vocal.start({ signal: controller.signal })
 controller.abort()
 ```
 
+### `stop()`
+
+Stops recognition gracefully, allowing the current audio to be processed before disconnecting. Sets `isRecording` to `false`.
+
+### `abort()`
+
+Stops recognition immediately without processing pending audio. Sets `isRecording` to `false`.
+
+### `addEventListener(eventType, callback)`
+
+Registers a callback for the given event type. Multiple callbacks can be registered for the same type — they stack and all fire in registration order.
+
+| Parameter | Type                                              | Description                                |
+| --------- | ------------------------------------------------- | ------------------------------------------ |
+| eventType | `EventType`                                       | One of the valid event type strings        |
+| callback  | `ResultEventHandler \| ErrorEventHandler \| GenericEventHandler` | Callback invoked when the event fires |
+
+Throws if `eventType` is not a valid `EventType`.
+
+### `removeEventListener(eventType, callback?)`
+
+Removes a listener for the given event type.
+
+| Parameter | Type                                              | Default     | Description                                          |
+| --------- | ------------------------------------------------- | ----------- | ---------------------------------------------------- |
+| eventType | `EventType`                                       |             | One of the valid event type strings                  |
+| callback  | `ResultEventHandler \| ErrorEventHandler \| GenericEventHandler` | `undefined` | Specific callback to remove. Omit to remove all listeners for this type |
+
+Throws if `eventType` is not a valid `EventType`.
+
 ### `once(eventType, callback)`
 
 Registers a one-shot listener that automatically unregisters itself after firing once.
@@ -123,4 +153,8 @@ vocal.once('result', (event, bestAlternative, alternatives) => {
     vocal.stop()
 })
 ```
+
+### `cleanup()`
+
+Stops recognition, removes all registered listeners, and releases the internal `SpeechRecognition` instance. The `Vocal` object cannot be reused after `cleanup()`.
 

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -66,7 +66,7 @@ class Vocal {
 	}
 
 	private _instance: SpeechRecognition | null = null
-	private _listeners: Record<string, Array<{ callback: EventHandler; handler: EventHandler }>> | null = null
+	private _listeners: Record<string, Array<{ callback: EventHandler; handler: EventHandler }>> = {}
 	private _isRecording: boolean = false
 	private _onEnd: () => void = () => {
 		this._isRecording = false
@@ -79,7 +79,6 @@ class Vocal {
 		}
 
 		this._instance = new SpeechRecognition()
-		this._listeners = {}
 
 		const { grammars, ...rest }: Required<VocalOptions> = {
 			...Vocal.defaultOptions,
@@ -152,7 +151,7 @@ class Vocal {
 		if (!this._includesEventType(eventType)) {
 			throw new Error(this._unknownEventTypeMessage(eventType))
 		}
-		if (this._instance && this._listeners) {
+		if (this._instance) {
 			const handler: EventHandler = (event) => {
 				const additionalArgs: unknown[] = []
 				if (eventType === Vocal.eventTypes.RESULT) {
@@ -188,7 +187,7 @@ class Vocal {
 			throw new Error(this._unknownEventTypeMessage(eventType))
 		}
 		const instance = this._instance
-		if (instance && this._listeners && this._listeners[eventType]) {
+		if (instance && this._listeners[eventType]) {
 			if (callback !== undefined) {
 				const idx = this._listeners[eventType].findIndex((e) => e.callback === callback)
 				if (idx !== -1) {
@@ -221,7 +220,7 @@ class Vocal {
 	cleanup(): this {
 		this.stop()
 
-		Object.keys(this._listeners!).forEach((key) => this.removeEventListener(key as EventType))
+		Object.keys(this._listeners).forEach((key) => this.removeEventListener(key as EventType))
 		this._instance?.removeEventListener('end', this._onEnd)
 		this._instance = null
 


### PR DESCRIPTION
## Summary

Two consistency fixes identified during a full beta audit:

### 1. `_listeners` type cleanup

`_listeners` was typed `| null` but was never actually `null` after construction — it was initialized to `{}` in the constructor and never reassigned to `null`. Changed to a plain `Record<...>` initialized at field level, removing the redundant constructor assignment and all `!` assertions / `&& this._listeners` guards.

### 2. Missing public method documentation

`stop()`, `abort()`, `addEventListener()`, `removeEventListener()`, and `cleanup()` were only shown in the Basic Usage example. Added dedicated entries to `## Methods` with parameter tables and descriptions — especially `removeEventListener(eventType, callback?)` whose optional callback parameter (added in #59) was entirely undocumented.

## Changes

- `src/Vocal.ts`: `_listeners` type `| null` → `{}`, remove constructor init, remove `!` assertion and null checks
- `README.md`: add `stop`, `abort`, `addEventListener`, `removeEventListener`, `cleanup` to Methods section