### PR TITLE
fix: Add Codecov token to workflow upload step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,4 +28,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       - uses: codecov/codecov-action@v6
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/lcov.info


### PR DESCRIPTION
## Summary

- Add missing `CODECOV_TOKEN` secret to `codecov/codecov-action` step in `publish.yml`
- Without this token, coverage uploads were failing silently, leaving the badge stuck at 63%

## Test plan

- [ ] Vérifier que le secret `CODECOV_TOKEN` est configuré dans les secrets GitHub du repo
- [ ] Merger et vérifier que le badge Codecov se met à jour à 100% après le prochain run CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)