### PR TITLE
feat: Add dev demo environment

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -220,10 +220,9 @@
 			}
 
 			/* Collapsible */
-			details.collapsible > .collapsible-summary { display: none; }
-
 			@media (min-width: 769px) {
 				details.collapsible { display: contents; }
+				details.collapsible > .collapsible-summary { display: none; }
 			}
 
 			@media (max-width: 768px) {
@@ -261,8 +260,6 @@
 				.collapsible-summary::-webkit-details-marker { display: none; }
 				.collapsible-summary::after { content: '▾'; font-size: 14px; }
 				details.collapsible[open] > .collapsible-summary::after { content: '▴'; }
-
-				.mobile-hidden { display: none; }
 			}
 
 			/* Responsive */
@@ -356,14 +353,12 @@
 				<!-- Once -->
 				<div class="card">
 					<div class="card-title">once()</div>
-					<p class="mobile-hidden" style="color:var(--muted);font-size:11px;margin-bottom:10px">Écoute un seul résultat puis se désenregistre automatiquement.</p>
 					<button class="btn-warn" id="btn-once" style="width:100%">Start + listen once</button>
 				</div>
 
 				<!-- AbortSignal -->
 				<div class="card">
 					<div class="card-title">AbortSignal</div>
-					<p class="mobile-hidden" style="color:var(--muted);font-size:11px;margin-bottom:10px">Démarre et annule via AbortController après 3s.</p>
 					<button class="btn-warn" id="btn-abort-signal" style="width:100%">Start with 3s abort</button>
 					<div id="abort-info"></div>
 				</div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -69,6 +69,15 @@
 				margin-bottom: 12px;
 			}
 
+			.card-header {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				margin-bottom: 12px;
+			}
+
+			.card-header .card-title { margin-bottom: 0; }
+
 			/* Status */
 			.status-row {
 				display: flex;
@@ -95,14 +104,16 @@
 			/* Config */
 			label {
 				display: flex;
-				flex-direction: column;
-				gap: 4px;
+				flex-direction: row;
+				align-items: center;
+				justify-content: space-between;
+				gap: 8px;
 				margin-bottom: 10px;
 				color: var(--muted);
 				font-size: 11px;
 			}
 
-			label:last-child { margin-bottom: 0; }
+			label input[type="text"], label input[type="number"] { width: 120px; flex-shrink: 0; }
 
 			select, input[type="number"], input[type="text"] {
 				background: var(--bg);
@@ -129,6 +140,7 @@
 
 			/* Controls */
 			.btn-group { display: flex; gap: 8px; flex-wrap: wrap; }
+			.btn-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
 
 			button {
 				font-family: var(--font);
@@ -149,16 +161,7 @@
 			.btn-secondary:hover:not(:disabled) { background: var(--border); }
 			.btn-danger { background: transparent; color: var(--danger); border-color: var(--danger); }
 			.btn-danger:hover:not(:disabled) { background: #3a1a1a; }
-			.btn-warn { background: transparent; color: var(--warn); border-color: var(--warn); }
-			.btn-warn:hover:not(:disabled) { background: #3a2a1a; }
-
-			/* Abort timer */
-			#abort-info {
-				margin-top: 10px;
-				font-size: 11px;
-				color: var(--muted);
-				min-height: 16px;
-			}
+			.btn-xs { font-size: 11px; padding: 4px 10px; }
 
 			/* Results */
 			.result-transcript {
@@ -173,6 +176,27 @@
 				font-size: 11px;
 				color: var(--muted);
 				min-height: 16px;
+			}
+
+			.alternatives-label {
+				margin-bottom: 4px;
+				font-weight: 600;
+				text-transform: uppercase;
+				letter-spacing: 0.06em;
+				font-size: 10px;
+			}
+
+			.alternatives-list {
+				list-style: none;
+				display: flex;
+				flex-direction: column;
+				gap: 3px;
+			}
+
+			.alternatives-list li::before {
+				content: '–';
+				margin-right: 6px;
+				color: var(--border);
 			}
 
 			/* Log */
@@ -213,12 +237,6 @@
 
 			.log-empty { color: var(--muted); font-size: 11px; text-align: center; padding: 24px 0; }
 
-			.log-actions {
-				display: flex;
-				justify-content: flex-end;
-				margin-top: 8px;
-			}
-
 			/* Collapsible */
 			@media (min-width: 769px) {
 				details.collapsible { display: contents; }
@@ -226,6 +244,18 @@
 			}
 
 			@media (max-width: 768px) {
+				body { padding: 16px; }
+
+				.grid { grid-template-columns: 1fr; }
+
+				button { padding: 10px 16px; min-height: 44px; }
+
+				.btn-group { gap: 10px; }
+				.btn-group button { flex: 1; min-width: 0; }
+				.btn-grid { gap: 10px; }
+
+				#log { height: 240px; }
+
 				details.collapsible {
 					background: var(--surface);
 					border: 1px solid var(--border);
@@ -262,20 +292,6 @@
 				details.collapsible[open] > .collapsible-summary::after { content: '▴'; }
 			}
 
-			/* Responsive */
-			@media (max-width: 768px) {
-				body { padding: 16px; }
-
-				.grid { grid-template-columns: 1fr; }
-
-				button { padding: 10px 16px; min-height: 44px; }
-
-				.btn-group { gap: 10px; }
-				.btn-group button { flex: 1; min-width: 0; }
-
-				#log { height: 240px; }
-			}
-
 			/* Unsupported overlay */
 			.unsupported {
 				background: #3a1a1a;
@@ -290,7 +306,7 @@
 	</head>
 	<body>
 		<h1>Vocal</h1>
-		<p class="subtitle">SpeechRecognition wrapper — dev demo</p>
+		<p class="subtitle">SpeechRecognition wrapper</p>
 
 		<div id="unsupported-banner" class="unsupported" style="display:none">
 			SpeechRecognition not supported in this browser. Try Chrome or Edge.
@@ -318,7 +334,10 @@
 
 					<!-- Config -->
 					<div class="card">
-						<div class="card-title">Options</div>
+						<div class="card-header">
+							<div class="card-title">Options</div>
+							<button class="btn-secondary btn-xs" id="btn-reinit">Reset</button>
+						</div>
 						<label>
 							lang
 							<input type="text" id="opt-lang" value="fr-FR" />
@@ -327,22 +346,23 @@
 							maxAlternatives
 							<input type="number" id="opt-maxalt" value="3" min="1" max="10" />
 						</label>
-						<label class="checkbox-row">
-							<input type="checkbox" id="opt-continuous" />
-							continuous
-						</label>
-						<label class="checkbox-row">
-							<input type="checkbox" id="opt-interim" />
-							interimResults
-						</label>
-						<button class="btn-secondary" id="btn-reinit" style="width:100%;margin-top:4px">Reinitialise</button>
+						<div style="display:flex;gap:16px">
+							<label class="checkbox-row" style="margin-bottom:0">
+								<input type="checkbox" id="opt-continuous" />
+								continuous
+							</label>
+							<label class="checkbox-row" style="margin-bottom:0">
+								<input type="checkbox" id="opt-interim" />
+								interimResults
+							</label>
+						</div>
 					</div>
 				</details>
 
 				<!-- Controls -->
 				<div class="card">
 					<div class="card-title">Controls</div>
-					<div class="btn-group">
+					<div class="btn-grid">
 						<button class="btn-primary" id="btn-start">Start</button>
 						<button class="btn-secondary" id="btn-stop" disabled>Stop</button>
 						<button class="btn-danger" id="btn-abort" disabled>Abort</button>
@@ -350,18 +370,6 @@
 					</div>
 				</div>
 
-				<!-- Once -->
-				<div class="card">
-					<div class="card-title">once()</div>
-					<button class="btn-warn" id="btn-once" style="width:100%">Start + listen once</button>
-				</div>
-
-				<!-- AbortSignal -->
-				<div class="card">
-					<div class="card-title">AbortSignal</div>
-					<button class="btn-warn" id="btn-abort-signal" style="width:100%">Start with 3s abort</button>
-					<div id="abort-info"></div>
-				</div>
 			</div>
 
 			<!-- Right column -->
@@ -375,11 +383,11 @@
 
 				<!-- Log -->
 				<div class="card" style="flex:1">
-					<div class="card-title">Events log</div>
-					<div id="log"><div class="log-empty">No events yet.</div></div>
-					<div class="log-actions">
-						<button class="btn-secondary" id="btn-clear-log" style="font-size:11px;padding:4px 10px">Clear</button>
+					<div class="card-header">
+						<div class="card-title">Logs</div>
+						<button class="btn-secondary btn-xs" id="btn-clear-log">Clear</button>
 					</div>
+					<div id="log"><div class="log-empty">No events yet.</div></div>
 				</div>
 			</div>
 		</div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,333 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Vocal — Dev Demo</title>
+		<style>
+			*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+			:root {
+				--bg: #0f0f13;
+				--surface: #1a1a24;
+				--border: #2e2e42;
+				--accent: #6c63ff;
+				--accent-hover: #8b85ff;
+				--danger: #ff5f5f;
+				--warn: #ffaa33;
+				--success: #4ade80;
+				--text: #e2e2f0;
+				--muted: #7070a0;
+				--radius: 8px;
+				--font: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+			}
+
+			body {
+				font-family: var(--font);
+				background: var(--bg);
+				color: var(--text);
+				min-height: 100vh;
+				padding: 24px;
+				font-size: 13px;
+			}
+
+			h1 {
+				font-size: 20px;
+				font-weight: 600;
+				margin-bottom: 4px;
+				color: #fff;
+			}
+
+			.subtitle {
+				color: var(--muted);
+				font-size: 12px;
+				margin-bottom: 24px;
+			}
+
+			.grid {
+				display: grid;
+				grid-template-columns: 320px 1fr;
+				gap: 16px;
+				max-width: 1100px;
+			}
+
+			.col { display: flex; flex-direction: column; gap: 16px; }
+
+			.card {
+				background: var(--surface);
+				border: 1px solid var(--border);
+				border-radius: var(--radius);
+				padding: 16px;
+			}
+
+			.card-title {
+				font-size: 11px;
+				font-weight: 600;
+				text-transform: uppercase;
+				letter-spacing: 0.08em;
+				color: var(--muted);
+				margin-bottom: 12px;
+			}
+
+			/* Status */
+			.status-row {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				margin-bottom: 8px;
+			}
+
+			.status-row:last-child { margin-bottom: 0; }
+
+			.badge {
+				font-size: 11px;
+				padding: 2px 8px;
+				border-radius: 100px;
+				font-weight: 600;
+			}
+
+			.badge.yes { background: #1a3a2a; color: var(--success); }
+			.badge.no  { background: #3a1a1a; color: var(--danger); }
+			.badge.recording { background: #2a1a3a; color: var(--accent); animation: pulse 1.2s ease-in-out infinite; }
+
+			@keyframes pulse { 0%,100%{ opacity:1; } 50%{ opacity:.5; } }
+
+			/* Config */
+			label {
+				display: flex;
+				flex-direction: column;
+				gap: 4px;
+				margin-bottom: 10px;
+				color: var(--muted);
+				font-size: 11px;
+			}
+
+			label:last-child { margin-bottom: 0; }
+
+			select, input[type="number"], input[type="text"] {
+				background: var(--bg);
+				border: 1px solid var(--border);
+				border-radius: 4px;
+				color: var(--text);
+				padding: 6px 8px;
+				font-family: var(--font);
+				font-size: 12px;
+				width: 100%;
+			}
+
+			.checkbox-row {
+				display: flex;
+				align-items: center;
+				gap: 8px;
+				margin-bottom: 10px;
+				font-size: 12px;
+				color: var(--text);
+				cursor: pointer;
+			}
+
+			.checkbox-row input { width: 14px; height: 14px; cursor: pointer; }
+
+			/* Controls */
+			.btn-group { display: flex; gap: 8px; flex-wrap: wrap; }
+
+			button {
+				font-family: var(--font);
+				font-size: 12px;
+				font-weight: 600;
+				padding: 7px 14px;
+				border-radius: 5px;
+				border: 1px solid transparent;
+				cursor: pointer;
+				transition: background 0.15s, opacity 0.15s;
+			}
+
+			button:disabled { opacity: 0.35; cursor: not-allowed; }
+
+			.btn-primary { background: var(--accent); color: #fff; border-color: var(--accent); }
+			.btn-primary:hover:not(:disabled) { background: var(--accent-hover); }
+			.btn-secondary { background: transparent; color: var(--text); border-color: var(--border); }
+			.btn-secondary:hover:not(:disabled) { background: var(--border); }
+			.btn-danger { background: transparent; color: var(--danger); border-color: var(--danger); }
+			.btn-danger:hover:not(:disabled) { background: #3a1a1a; }
+			.btn-warn { background: transparent; color: var(--warn); border-color: var(--warn); }
+			.btn-warn:hover:not(:disabled) { background: #3a2a1a; }
+
+			/* Abort timer */
+			#abort-info {
+				margin-top: 10px;
+				font-size: 11px;
+				color: var(--muted);
+				min-height: 16px;
+			}
+
+			/* Results */
+			.result-transcript {
+				font-size: 16px;
+				color: #fff;
+				min-height: 28px;
+				margin-bottom: 8px;
+				word-break: break-word;
+			}
+
+			.result-alternatives {
+				font-size: 11px;
+				color: var(--muted);
+				min-height: 16px;
+			}
+
+			/* Log */
+			#log {
+				height: 360px;
+				overflow-y: auto;
+				display: flex;
+				flex-direction: column;
+				gap: 4px;
+			}
+
+			.log-entry {
+				display: flex;
+				gap: 8px;
+				align-items: flex-start;
+				font-size: 11px;
+				padding: 4px 6px;
+				border-radius: 4px;
+				background: var(--bg);
+				border-left: 3px solid var(--border);
+			}
+
+			.log-entry.event-result  { border-color: var(--success); }
+			.log-entry.event-error   { border-color: var(--danger); }
+			.log-entry.event-start   { border-color: var(--accent); }
+			.log-entry.event-end     { border-color: var(--muted); }
+			.log-entry.event-nomatch { border-color: var(--warn); }
+
+			.log-time { color: var(--muted); white-space: nowrap; flex-shrink: 0; }
+			.log-type { font-weight: 700; white-space: nowrap; flex-shrink: 0; min-width: 80px; }
+			.log-msg  { color: var(--muted); word-break: break-all; }
+
+			.log-entry.event-result  .log-type { color: var(--success); }
+			.log-entry.event-error   .log-type { color: var(--danger); }
+			.log-entry.event-start   .log-type { color: var(--accent); }
+			.log-entry.event-end     .log-type { color: var(--muted); }
+			.log-entry.event-nomatch .log-type { color: var(--warn); }
+
+			.log-empty { color: var(--muted); font-size: 11px; text-align: center; padding: 24px 0; }
+
+			.log-actions {
+				display: flex;
+				justify-content: flex-end;
+				margin-top: 8px;
+			}
+
+			/* Unsupported overlay */
+			.unsupported {
+				background: #3a1a1a;
+				border: 1px solid var(--danger);
+				border-radius: var(--radius);
+				padding: 16px;
+				color: var(--danger);
+				margin-bottom: 16px;
+				font-size: 12px;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>Vocal</h1>
+		<p class="subtitle">SpeechRecognition wrapper — dev demo</p>
+
+		<div id="unsupported-banner" class="unsupported" style="display:none">
+			SpeechRecognition not supported in this browser. Try Chrome or Edge.
+		</div>
+
+		<div class="grid">
+			<!-- Left column -->
+			<div class="col">
+				<!-- Status -->
+				<div class="card">
+					<div class="card-title">Status</div>
+					<div class="status-row">
+						<span>isSupported</span>
+						<span id="status-supported" class="badge no">false</span>
+					</div>
+					<div class="status-row">
+						<span>isRecording</span>
+						<span id="status-recording" class="badge no">false</span>
+					</div>
+					<div class="status-row">
+						<span>instance</span>
+						<span id="status-instance" class="badge no">null</span>
+					</div>
+				</div>
+
+				<!-- Config -->
+				<div class="card">
+					<div class="card-title">Options</div>
+					<label>
+						lang
+						<input type="text" id="opt-lang" value="fr-FR" />
+					</label>
+					<label>
+						maxAlternatives
+						<input type="number" id="opt-maxalt" value="3" min="1" max="10" />
+					</label>
+					<label class="checkbox-row">
+						<input type="checkbox" id="opt-continuous" />
+						continuous
+					</label>
+					<label class="checkbox-row">
+						<input type="checkbox" id="opt-interim" />
+						interimResults
+					</label>
+					<button class="btn-secondary" id="btn-reinit" style="width:100%;margin-top:4px">Reinitialise</button>
+				</div>
+
+				<!-- Controls -->
+				<div class="card">
+					<div class="card-title">Controls</div>
+					<div class="btn-group">
+						<button class="btn-primary" id="btn-start">Start</button>
+						<button class="btn-secondary" id="btn-stop" disabled>Stop</button>
+						<button class="btn-danger" id="btn-abort" disabled>Abort</button>
+						<button class="btn-secondary" id="btn-cleanup" disabled>Cleanup</button>
+					</div>
+				</div>
+
+				<!-- Once -->
+				<div class="card">
+					<div class="card-title">once()</div>
+					<p style="color:var(--muted);font-size:11px;margin-bottom:10px">Écoute un seul résultat puis se désenregistre automatiquement.</p>
+					<button class="btn-warn" id="btn-once" style="width:100%">Start + listen once</button>
+				</div>
+
+				<!-- AbortSignal -->
+				<div class="card">
+					<div class="card-title">AbortSignal</div>
+					<p style="color:var(--muted);font-size:11px;margin-bottom:10px">Démarre et annule via AbortController après 3s.</p>
+					<button class="btn-warn" id="btn-abort-signal" style="width:100%">Start with 3s abort</button>
+					<div id="abort-info"></div>
+				</div>
+			</div>
+
+			<!-- Right column -->
+			<div class="col">
+				<!-- Result -->
+				<div class="card">
+					<div class="card-title">Last result</div>
+					<div class="result-transcript" id="result-transcript">—</div>
+					<div class="result-alternatives" id="result-alternatives"></div>
+				</div>
+
+				<!-- Log -->
+				<div class="card" style="flex:1">
+					<div class="card-title">Events log</div>
+					<div id="log"><div class="log-empty">No events yet.</div></div>
+					<div class="log-actions">
+						<button class="btn-secondary" id="btn-clear-log" style="font-size:11px;padding:4px 10px">Clear</button>
+					</div>
+				</div>
+			</div>
+		</div>
+
+		<script type="module" src="./main.ts"></script>
+	</body>
+</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -253,10 +253,6 @@
 						<span>isRecording</span>
 						<span id="status-recording" class="badge no">false</span>
 					</div>
-					<div class="status-row">
-						<span>instance</span>
-						<span id="status-instance" class="badge no">null</span>
-					</div>
 				</div>
 
 				<!-- Config -->

--- a/demo/index.html
+++ b/demo/index.html
@@ -139,6 +139,7 @@
 			.checkbox-row input { width: 14px; height: 14px; cursor: pointer; }
 
 			.checkbox-group { display: flex; gap: 16px; }
+			.checkbox-group .checkbox-row { margin-bottom: 0; }
 
 			.grow { flex: 1; }
 
@@ -351,11 +352,11 @@
 							<input type="number" id="opt-maxalt" value="3" min="1" max="10" />
 						</label>
 						<div class="checkbox-group">
-							<label class="checkbox-row" style="margin-bottom:0">
+							<label class="checkbox-row">
 								<input type="checkbox" id="opt-continuous" />
 								continuous
 							</label>
-							<label class="checkbox-row" style="margin-bottom:0">
+							<label class="checkbox-row">
 								<input type="checkbox" id="opt-interim" />
 								interimResults
 							</label>

--- a/demo/index.html
+++ b/demo/index.html
@@ -138,6 +138,10 @@
 
 			.checkbox-row input { width: 14px; height: 14px; cursor: pointer; }
 
+			.checkbox-group { display: flex; gap: 16px; }
+
+			.grow { flex: 1; }
+
 			/* Controls */
 			.btn-group { display: flex; gap: 8px; flex-wrap: wrap; }
 			.btn-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
@@ -346,7 +350,7 @@
 							maxAlternatives
 							<input type="number" id="opt-maxalt" value="3" min="1" max="10" />
 						</label>
-						<div style="display:flex;gap:16px">
+						<div class="checkbox-group">
 							<label class="checkbox-row" style="margin-bottom:0">
 								<input type="checkbox" id="opt-continuous" />
 								continuous
@@ -382,7 +386,7 @@
 				</div>
 
 				<!-- Log -->
-				<div class="card" style="flex:1">
+				<div class="card grow">
 					<div class="card-header">
 						<div class="card-title">Logs</div>
 						<button class="btn-secondary btn-xs" id="btn-clear-log">Clear</button>

--- a/demo/index.html
+++ b/demo/index.html
@@ -219,6 +219,20 @@
 				margin-top: 8px;
 			}
 
+			/* Responsive */
+			@media (max-width: 768px) {
+				body { padding: 16px; }
+
+				.grid { grid-template-columns: 1fr; }
+
+				button { padding: 10px 16px; min-height: 44px; }
+
+				.btn-group { gap: 10px; }
+				.btn-group button { flex: 1; min-width: 0; }
+
+				#log { height: 240px; }
+			}
+
 			/* Unsupported overlay */
 			.unsupported {
 				background: #3a1a1a;

--- a/demo/index.html
+++ b/demo/index.html
@@ -219,6 +219,52 @@
 				margin-top: 8px;
 			}
 
+			/* Collapsible */
+			details.collapsible > .collapsible-summary { display: none; }
+
+			@media (min-width: 769px) {
+				details.collapsible { display: contents; }
+			}
+
+			@media (max-width: 768px) {
+				details.collapsible {
+					background: var(--surface);
+					border: 1px solid var(--border);
+					border-radius: var(--radius);
+					overflow: hidden;
+				}
+
+				details.collapsible > .card {
+					border-left: none;
+					border-right: none;
+					border-radius: 0;
+					border-top: 1px solid var(--border);
+					border-bottom: none;
+				}
+
+				.collapsible-summary {
+					display: flex;
+					justify-content: space-between;
+					align-items: center;
+					padding: 12px 16px;
+					min-height: 44px;
+					cursor: pointer;
+					list-style: none;
+					font-size: 11px;
+					font-weight: 600;
+					text-transform: uppercase;
+					letter-spacing: 0.08em;
+					color: var(--muted);
+					user-select: none;
+				}
+
+				.collapsible-summary::-webkit-details-marker { display: none; }
+				.collapsible-summary::after { content: '▾'; font-size: 14px; }
+				details.collapsible[open] > .collapsible-summary::after { content: '▴'; }
+
+				.mobile-hidden { display: none; }
+			}
+
 			/* Responsive */
 			@media (max-width: 768px) {
 				body { padding: 16px; }
@@ -256,40 +302,45 @@
 		<div class="grid">
 			<!-- Left column -->
 			<div class="col">
-				<!-- Status -->
-				<div class="card">
-					<div class="card-title">Status</div>
-					<div class="status-row">
-						<span>isSupported</span>
-						<span id="status-supported" class="badge no">false</span>
-					</div>
-					<div class="status-row">
-						<span>isRecording</span>
-						<span id="status-recording" class="badge no">false</span>
-					</div>
-				</div>
+				<!-- Status + Options collapsible -->
+				<details class="collapsible" id="panel-config">
+					<summary class="collapsible-summary">Status &amp; Options</summary>
 
-				<!-- Config -->
-				<div class="card">
-					<div class="card-title">Options</div>
-					<label>
-						lang
-						<input type="text" id="opt-lang" value="fr-FR" />
-					</label>
-					<label>
-						maxAlternatives
-						<input type="number" id="opt-maxalt" value="3" min="1" max="10" />
-					</label>
-					<label class="checkbox-row">
-						<input type="checkbox" id="opt-continuous" />
-						continuous
-					</label>
-					<label class="checkbox-row">
-						<input type="checkbox" id="opt-interim" />
-						interimResults
-					</label>
-					<button class="btn-secondary" id="btn-reinit" style="width:100%;margin-top:4px">Reinitialise</button>
-				</div>
+					<!-- Status -->
+					<div class="card">
+						<div class="card-title">Status</div>
+						<div class="status-row">
+							<span>isSupported</span>
+							<span id="status-supported" class="badge no">false</span>
+						</div>
+						<div class="status-row">
+							<span>isRecording</span>
+							<span id="status-recording" class="badge no">false</span>
+						</div>
+					</div>
+
+					<!-- Config -->
+					<div class="card">
+						<div class="card-title">Options</div>
+						<label>
+							lang
+							<input type="text" id="opt-lang" value="fr-FR" />
+						</label>
+						<label>
+							maxAlternatives
+							<input type="number" id="opt-maxalt" value="3" min="1" max="10" />
+						</label>
+						<label class="checkbox-row">
+							<input type="checkbox" id="opt-continuous" />
+							continuous
+						</label>
+						<label class="checkbox-row">
+							<input type="checkbox" id="opt-interim" />
+							interimResults
+						</label>
+						<button class="btn-secondary" id="btn-reinit" style="width:100%;margin-top:4px">Reinitialise</button>
+					</div>
+				</details>
 
 				<!-- Controls -->
 				<div class="card">
@@ -305,14 +356,14 @@
 				<!-- Once -->
 				<div class="card">
 					<div class="card-title">once()</div>
-					<p style="color:var(--muted);font-size:11px;margin-bottom:10px">Écoute un seul résultat puis se désenregistre automatiquement.</p>
+					<p class="mobile-hidden" style="color:var(--muted);font-size:11px;margin-bottom:10px">Écoute un seul résultat puis se désenregistre automatiquement.</p>
 					<button class="btn-warn" id="btn-once" style="width:100%">Start + listen once</button>
 				</div>
 
 				<!-- AbortSignal -->
 				<div class="card">
 					<div class="card-title">AbortSignal</div>
-					<p style="color:var(--muted);font-size:11px;margin-bottom:10px">Démarre et annule via AbortController après 3s.</p>
+					<p class="mobile-hidden" style="color:var(--muted);font-size:11px;margin-bottom:10px">Démarre et annule via AbortController après 3s.</p>
 					<button class="btn-warn" id="btn-abort-signal" style="width:100%">Start with 3s abort</button>
 					<div id="abort-info"></div>
 				</div>

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -105,13 +105,6 @@ function buildOptions() {
 
 // ── Permission ────────────────────────────────────────────────────────────────
 
-// Chrome requires an explicit getUserMedia call before SpeechRecognition.start()
-// to ensure the mic permission is granted — without it, recognition silently fails.
-async function ensurePermission(): Promise<void> {
-	const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
-	stream.getTracks().forEach((t) => t.stop())
-}
-
 // ── Vocal lifecycle ───────────────────────────────────────────────────────────
 
 function logEvent(type: string) {
@@ -182,7 +175,6 @@ $btnReinit.addEventListener('click', initVocal)
 $btnStart.addEventListener('click', async () => {
 	if (!vocal) return
 	try {
-		await ensurePermission()
 		await vocal.start()
 	} catch (e) {
 		log('error', String(e))

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -89,15 +89,9 @@ function updateStatus() {
 	$btnCleanup.disabled = !vocal
 }
 
-function setBadge(
-	el: HTMLElement,
-	value: boolean,
-	trueClass?: string,
-	trueLabel = 'true',
-	falseLabel = 'false'
-) {
+function setBadge(el: HTMLElement, value: boolean, trueClass?: string) {
 	el.className = `badge ${value ? (trueClass ?? 'yes') : 'no'}`
-	el.textContent = value ? trueLabel : falseLabel
+	el.textContent = String(value)
 }
 
 function buildOptions() {
@@ -111,6 +105,8 @@ function buildOptions() {
 
 // ── Permission ────────────────────────────────────────────────────────────────
 
+// Chrome requires an explicit getUserMedia call before SpeechRecognition.start()
+// to ensure the mic permission is granted — without it, recognition silently fails.
 async function ensurePermission(): Promise<void> {
 	const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
 	stream.getTracks().forEach((t) => t.stop())
@@ -205,6 +201,8 @@ $btnAbort.addEventListener('click', () => {
 })
 
 $btnCleanup.addEventListener('click', () => {
+	vocal?.cleanup()
+	vocal = null
 	log('cleanup')
 	initVocal()
 })

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -57,7 +57,7 @@ function log(type: string, msg = '') {
 }
 
 function setAlternatives(alts: string[], label = 'Alternatives') {
-	$alternatives.innerHTML = ''
+	$alternatives.replaceChildren()
 	if (alts.length <= 1) return
 	const heading = document.createElement('div')
 	heading.className = 'alternatives-label'
@@ -102,8 +102,6 @@ function buildOptions() {
 		interimResults: $optInterim.checked,
 	}
 }
-
-// ── Permission ────────────────────────────────────────────────────────────────
 
 // ── Vocal lifecycle ───────────────────────────────────────────────────────────
 
@@ -200,5 +198,8 @@ $btnCleanup.addEventListener('click', () => {
 })
 
 $btnClearLog.addEventListener('click', () => {
-	$log.innerHTML = '<div class="log-empty">No events yet.</div>'
+	const empty = document.createElement('div')
+	empty.className = 'log-empty'
+	empty.textContent = 'No events yet.'
+	$log.replaceChildren(empty)
 })

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -87,6 +87,13 @@ function buildOptions() {
 	}
 }
 
+// ── Permission ────────────────────────────────────────────────────────────────
+
+async function ensurePermission(): Promise<void> {
+	const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+	stream.getTracks().forEach((t) => t.stop())
+}
+
 // ── Vocal lifecycle ───────────────────────────────────────────────────────────
 
 function initVocal() {
@@ -171,6 +178,7 @@ $btnReinit.addEventListener('click', () => {
 $btnStart.addEventListener('click', async () => {
 	if (!vocal) return
 	try {
+		await ensurePermission()
 		await vocal.start()
 	} catch (e) {
 		log('error', String(e))
@@ -207,6 +215,7 @@ $btnOnce.addEventListener('click', async () => {
 		updateStatus()
 	})
 	try {
+		await ensurePermission()
 		await vocal.start()
 	} catch (e) {
 		log('error', String(e))
@@ -229,6 +238,7 @@ $btnAbortSignal.addEventListener('click', async () => {
 	}, 3000)
 
 	try {
+		await ensurePermission()
 		await vocal.start({ signal: controller.signal })
 	} catch (e) {
 		clearTimeout(timer)

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -2,30 +2,28 @@ import { Vocal } from '../src/index'
 
 // ── DOM refs ──────────────────────────────────────────────────────────────────
 
-const $supported   = document.getElementById('status-supported')!
-const $recording   = document.getElementById('status-recording')!
-const $transcript  = document.getElementById('result-transcript')!
+const $supported    = document.getElementById('status-supported')!
+const $recording    = document.getElementById('status-recording')!
+const $transcript   = document.getElementById('result-transcript')!
 const $alternatives = document.getElementById('result-alternatives')!
-const $log         = document.getElementById('log')!
-const $abortInfo   = document.getElementById('abort-info')!
-const $banner      = document.getElementById('unsupported-banner')!
+const $log          = document.getElementById('log')!
+const $banner       = document.getElementById('unsupported-banner')!
 
-const $optLang      = document.getElementById('opt-lang') as HTMLInputElement
-const $optMaxAlt    = document.getElementById('opt-maxalt') as HTMLInputElement
+const $optLang       = document.getElementById('opt-lang') as HTMLInputElement
+const $optMaxAlt     = document.getElementById('opt-maxalt') as HTMLInputElement
 const $optContinuous = document.getElementById('opt-continuous') as HTMLInputElement
-const $optInterim   = document.getElementById('opt-interim') as HTMLInputElement
+const $optInterim    = document.getElementById('opt-interim') as HTMLInputElement
 
-const $btnStart       = document.getElementById('btn-start') as HTMLButtonElement
-const $btnStop        = document.getElementById('btn-stop') as HTMLButtonElement
-const $btnAbort       = document.getElementById('btn-abort') as HTMLButtonElement
-const $btnCleanup     = document.getElementById('btn-cleanup') as HTMLButtonElement
-const $btnReinit      = document.getElementById('btn-reinit') as HTMLButtonElement
-const $btnOnce        = document.getElementById('btn-once') as HTMLButtonElement
-const $btnAbortSignal = document.getElementById('btn-abort-signal') as HTMLButtonElement
-const $btnClearLog    = document.getElementById('btn-clear-log') as HTMLButtonElement
+const $btnStart   = document.getElementById('btn-start') as HTMLButtonElement
+const $btnStop    = document.getElementById('btn-stop') as HTMLButtonElement
+const $btnAbort   = document.getElementById('btn-abort') as HTMLButtonElement
+const $btnCleanup = document.getElementById('btn-cleanup') as HTMLButtonElement
+const $btnReinit  = document.getElementById('btn-reinit') as HTMLButtonElement
+const $btnClearLog = document.getElementById('btn-clear-log') as HTMLButtonElement
 
 // ── State ─────────────────────────────────────────────────────────────────────
 
+const isSupported = Vocal.isSupported
 let vocal: Vocal | null = null
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -40,17 +38,43 @@ function log(type: string, msg = '') {
 
 	const entry = document.createElement('div')
 	entry.className = `log-entry event-${type}`
-	entry.innerHTML = `
-		<span class="log-time">${time()}</span>
-		<span class="log-type">${type}</span>
-		<span class="log-msg">${msg}</span>
-	`
-	$log.prepend(entry)
+
+	const $time = document.createElement('span')
+	$time.className = 'log-time'
+	$time.textContent = time()
+
+	const $type = document.createElement('span')
+	$type.className = 'log-type'
+	$type.textContent = type
+
+	const $msg = document.createElement('span')
+	$msg.className = 'log-msg'
+	$msg.textContent = msg
+
+	entry.append($time, $type, $msg)
+	$log.appendChild(entry)
+	$log.scrollTop = $log.scrollHeight
+}
+
+function setAlternatives(alts: string[], label = 'Alternatives') {
+	$alternatives.innerHTML = ''
+	if (alts.length <= 1) return
+	const heading = document.createElement('div')
+	heading.className = 'alternatives-label'
+	heading.textContent = label
+	const ul = document.createElement('ul')
+	ul.className = 'alternatives-list'
+	alts.slice(1).forEach((a) => {
+		const li = document.createElement('li')
+		li.textContent = a
+		ul.appendChild(li)
+	})
+	$alternatives.appendChild(heading)
+	$alternatives.appendChild(ul)
 }
 
 function updateStatus() {
-	const supported = Vocal.isSupported
-	setBadge($supported, supported)
+	setBadge($supported, isSupported)
 
 	if (vocal) {
 		const recording = vocal.isRecording
@@ -63,8 +87,6 @@ function updateStatus() {
 	$btnStop.disabled    = !vocal || !vocal.isRecording
 	$btnAbort.disabled   = !vocal || !vocal.isRecording
 	$btnCleanup.disabled = !vocal
-	$btnOnce.disabled    = !vocal || vocal.isRecording
-	$btnAbortSignal.disabled = !vocal || vocal.isRecording
 }
 
 function setBadge(
@@ -96,30 +118,22 @@ async function ensurePermission(): Promise<void> {
 
 // ── Vocal lifecycle ───────────────────────────────────────────────────────────
 
+function logEvent(type: string) {
+	return () => { log(type); updateStatus() }
+}
+
 function initVocal() {
 	if (vocal) {
 		vocal.cleanup()
 		vocal = null
 	}
 
-	vocal = new Vocal(buildOptions())
-
-	vocal.addEventListener('start', () => {
-		log('start')
-		updateStatus()
-	})
-
-	vocal.addEventListener('end', () => {
-		log('end')
-		updateStatus()
-	})
+	const options = buildOptions()
+	vocal = new Vocal(options)
 
 	vocal.addEventListener('result', (_, best, alts) => {
 		$transcript.textContent = best as string
-		const alternatives = alts as string[]
-		$alternatives.textContent = alternatives.length > 1
-			? `Alternatives: ${alternatives.slice(1).join(' · ')}`
-			: ''
+		setAlternatives(alts as string[])
 		log('result', best as string)
 		updateStatus()
 	})
@@ -130,19 +144,17 @@ function initVocal() {
 		updateStatus()
 	})
 
-	vocal.addEventListener('nomatch', () => {
-		log('nomatch')
-		updateStatus()
-	})
+	vocal.addEventListener('start',       logEvent('start'))
+	vocal.addEventListener('end',         logEvent('end'))
+	vocal.addEventListener('nomatch',     logEvent('nomatch'))
+	vocal.addEventListener('audiostart',  logEvent('audiostart'))
+	vocal.addEventListener('audioend',    logEvent('audioend'))
+	vocal.addEventListener('soundstart',  logEvent('soundstart'))
+	vocal.addEventListener('soundend',    logEvent('soundend'))
+	vocal.addEventListener('speechstart', logEvent('speechstart'))
+	vocal.addEventListener('speechend',   logEvent('speechend'))
 
-	vocal.addEventListener('audiostart',  () => { log('audiostart');  updateStatus() })
-	vocal.addEventListener('audioend',    () => { log('audioend');    updateStatus() })
-	vocal.addEventListener('soundstart',  () => { log('soundstart');  updateStatus() })
-	vocal.addEventListener('soundend',    () => { log('soundend');    updateStatus() })
-	vocal.addEventListener('speechstart', () => { log('speechstart'); updateStatus() })
-	vocal.addEventListener('speechend',   () => { log('speechend');   updateStatus() })
-
-	log('init', JSON.stringify(buildOptions()))
+	log('init', JSON.stringify(options))
 	updateStatus()
 }
 
@@ -158,22 +170,18 @@ window.addEventListener('resize', syncCollapsible)
 
 // ── Init ──────────────────────────────────────────────────────────────────────
 
-if (!Vocal.isSupported) {
+if (!isSupported) {
 	$banner.style.display = 'block'
-	;[$btnStart, $btnStop, $btnAbort, $btnCleanup, $btnOnce, $btnAbortSignal, $btnReinit].forEach(
+	;[$btnStart, $btnStop, $btnAbort, $btnCleanup, $btnReinit].forEach(
 		(b) => (b.disabled = true)
 	)
 } else {
 	initVocal()
 }
 
-updateStatus()
-
 // ── Bindings ──────────────────────────────────────────────────────────────────
 
-$btnReinit.addEventListener('click', () => {
-	initVocal()
-})
+$btnReinit.addEventListener('click', initVocal)
 
 $btnStart.addEventListener('click', async () => {
 	if (!vocal) return
@@ -197,56 +205,8 @@ $btnAbort.addEventListener('click', () => {
 })
 
 $btnCleanup.addEventListener('click', () => {
-	vocal?.cleanup()
-	vocal = null
 	log('cleanup')
-	updateStatus()
-})
-
-$btnOnce.addEventListener('click', async () => {
-	if (!vocal) return
-	vocal.once('result', (_, best, alts) => {
-		$transcript.textContent = best as string
-		const alternatives = alts as string[]
-		$alternatives.textContent = alternatives.length > 1
-			? `once() alternatives: ${alternatives.slice(1).join(' · ')}`
-			: ''
-		log('result [once]', best as string)
-		updateStatus()
-	})
-	try {
-		await ensurePermission()
-		await vocal.start()
-	} catch (e) {
-		log('error', String(e))
-	}
-	updateStatus()
-})
-
-$btnAbortSignal.addEventListener('click', async () => {
-	if (!vocal) return
-	const controller = new AbortController()
-	$abortInfo.textContent = 'Abort dans 3s...'
-	$btnAbortSignal.disabled = true
-
-	const timer = setTimeout(() => {
-		controller.abort()
-		$abortInfo.textContent = 'Aborted via AbortSignal.'
-		$btnAbortSignal.disabled = false
-		log('abort-signal', 'AbortController.abort() appelé après 3s')
-		updateStatus()
-	}, 3000)
-
-	try {
-		await ensurePermission()
-		await vocal.start({ signal: controller.signal })
-	} catch (e) {
-		clearTimeout(timer)
-		$abortInfo.textContent = ''
-		$btnAbortSignal.disabled = false
-		log('error', String(e))
-	}
-	updateStatus()
+	initVocal()
 })
 
 $btnClearLog.addEventListener('click', () => {

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -4,7 +4,6 @@ import { Vocal } from '../src/index'
 
 const $supported   = document.getElementById('status-supported')!
 const $recording   = document.getElementById('status-recording')!
-const $instance    = document.getElementById('status-instance')!
 const $transcript  = document.getElementById('result-transcript')!
 const $alternatives = document.getElementById('result-alternatives')!
 const $log         = document.getElementById('log')!
@@ -56,10 +55,8 @@ function updateStatus() {
 	if (vocal) {
 		const recording = vocal.isRecording
 		setBadge($recording, recording, recording ? 'recording' : undefined)
-		setBadge($instance, true, undefined, 'active', 'null')
 	} else {
 		setBadge($recording, false)
-		setBadge($instance, false, undefined, 'active', 'null')
 	}
 
 	$btnStart.disabled   = !vocal || vocal.isRecording

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -1,0 +1,237 @@
+import { Vocal } from '../src/index'
+
+// ── DOM refs ──────────────────────────────────────────────────────────────────
+
+const $supported   = document.getElementById('status-supported')!
+const $recording   = document.getElementById('status-recording')!
+const $instance    = document.getElementById('status-instance')!
+const $transcript  = document.getElementById('result-transcript')!
+const $alternatives = document.getElementById('result-alternatives')!
+const $log         = document.getElementById('log')!
+const $abortInfo   = document.getElementById('abort-info')!
+const $banner      = document.getElementById('unsupported-banner')!
+
+const $optLang      = document.getElementById('opt-lang') as HTMLInputElement
+const $optMaxAlt    = document.getElementById('opt-maxalt') as HTMLInputElement
+const $optContinuous = document.getElementById('opt-continuous') as HTMLInputElement
+const $optInterim   = document.getElementById('opt-interim') as HTMLInputElement
+
+const $btnStart       = document.getElementById('btn-start') as HTMLButtonElement
+const $btnStop        = document.getElementById('btn-stop') as HTMLButtonElement
+const $btnAbort       = document.getElementById('btn-abort') as HTMLButtonElement
+const $btnCleanup     = document.getElementById('btn-cleanup') as HTMLButtonElement
+const $btnReinit      = document.getElementById('btn-reinit') as HTMLButtonElement
+const $btnOnce        = document.getElementById('btn-once') as HTMLButtonElement
+const $btnAbortSignal = document.getElementById('btn-abort-signal') as HTMLButtonElement
+const $btnClearLog    = document.getElementById('btn-clear-log') as HTMLButtonElement
+
+// ── State ─────────────────────────────────────────────────────────────────────
+
+let vocal: Vocal | null = null
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function time(): string {
+	return new Date().toLocaleTimeString('fr-FR', { hour12: false })
+}
+
+function log(type: string, msg = '') {
+	const empty = $log.querySelector('.log-empty')
+	if (empty) empty.remove()
+
+	const entry = document.createElement('div')
+	entry.className = `log-entry event-${type}`
+	entry.innerHTML = `
+		<span class="log-time">${time()}</span>
+		<span class="log-type">${type}</span>
+		<span class="log-msg">${msg}</span>
+	`
+	$log.prepend(entry)
+}
+
+function updateStatus() {
+	const supported = Vocal.isSupported
+	setBadge($supported, supported)
+
+	if (vocal) {
+		const recording = vocal.isRecording
+		setBadge($recording, recording, recording ? 'recording' : undefined)
+		setBadge($instance, true, undefined, 'active', 'null')
+	} else {
+		setBadge($recording, false)
+		setBadge($instance, false, undefined, 'active', 'null')
+	}
+
+	$btnStart.disabled   = !vocal || vocal.isRecording
+	$btnStop.disabled    = !vocal || !vocal.isRecording
+	$btnAbort.disabled   = !vocal || !vocal.isRecording
+	$btnCleanup.disabled = !vocal
+	$btnOnce.disabled    = !vocal || vocal.isRecording
+	$btnAbortSignal.disabled = !vocal || vocal.isRecording
+}
+
+function setBadge(
+	el: HTMLElement,
+	value: boolean,
+	trueClass?: string,
+	trueLabel = 'true',
+	falseLabel = 'false'
+) {
+	el.className = `badge ${value ? (trueClass ?? 'yes') : 'no'}`
+	el.textContent = value ? trueLabel : falseLabel
+}
+
+function buildOptions() {
+	return {
+		lang: $optLang.value || 'fr-FR',
+		maxAlternatives: parseInt($optMaxAlt.value, 10) || 1,
+		continuous: $optContinuous.checked,
+		interimResults: $optInterim.checked,
+	}
+}
+
+// ── Vocal lifecycle ───────────────────────────────────────────────────────────
+
+function initVocal() {
+	if (vocal) {
+		vocal.cleanup()
+		vocal = null
+	}
+
+	vocal = new Vocal(buildOptions())
+
+	vocal.addEventListener('start', () => {
+		log('start')
+		updateStatus()
+	})
+
+	vocal.addEventListener('end', () => {
+		log('end')
+		updateStatus()
+	})
+
+	vocal.addEventListener('result', (_, best, alts) => {
+		$transcript.textContent = best as string
+		const alternatives = alts as string[]
+		$alternatives.textContent = alternatives.length > 1
+			? `Alternatives: ${alternatives.slice(1).join(' · ')}`
+			: ''
+		log('result', best as string)
+		updateStatus()
+	})
+
+	vocal.addEventListener('error', (e) => {
+		const err = e as SpeechRecognitionErrorEvent
+		log('error', err.error ?? String(e))
+		updateStatus()
+	})
+
+	vocal.addEventListener('nomatch', () => {
+		log('nomatch')
+		updateStatus()
+	})
+
+	vocal.addEventListener('audiostart',  () => { log('audiostart');  updateStatus() })
+	vocal.addEventListener('audioend',    () => { log('audioend');    updateStatus() })
+	vocal.addEventListener('soundstart',  () => { log('soundstart');  updateStatus() })
+	vocal.addEventListener('soundend',    () => { log('soundend');    updateStatus() })
+	vocal.addEventListener('speechstart', () => { log('speechstart'); updateStatus() })
+	vocal.addEventListener('speechend',   () => { log('speechend');   updateStatus() })
+
+	log('init', JSON.stringify(buildOptions()))
+	updateStatus()
+}
+
+// ── Init ──────────────────────────────────────────────────────────────────────
+
+if (!Vocal.isSupported) {
+	$banner.style.display = 'block'
+	;[$btnStart, $btnStop, $btnAbort, $btnCleanup, $btnOnce, $btnAbortSignal, $btnReinit].forEach(
+		(b) => (b.disabled = true)
+	)
+} else {
+	initVocal()
+}
+
+updateStatus()
+
+// ── Bindings ──────────────────────────────────────────────────────────────────
+
+$btnReinit.addEventListener('click', () => {
+	initVocal()
+})
+
+$btnStart.addEventListener('click', async () => {
+	if (!vocal) return
+	try {
+		await vocal.start()
+	} catch (e) {
+		log('error', String(e))
+	}
+	updateStatus()
+})
+
+$btnStop.addEventListener('click', () => {
+	vocal?.stop()
+	updateStatus()
+})
+
+$btnAbort.addEventListener('click', () => {
+	vocal?.abort()
+	updateStatus()
+})
+
+$btnCleanup.addEventListener('click', () => {
+	vocal?.cleanup()
+	vocal = null
+	log('cleanup')
+	updateStatus()
+})
+
+$btnOnce.addEventListener('click', async () => {
+	if (!vocal) return
+	vocal.once('result', (_, best, alts) => {
+		$transcript.textContent = best as string
+		const alternatives = alts as string[]
+		$alternatives.textContent = alternatives.length > 1
+			? `once() alternatives: ${alternatives.slice(1).join(' · ')}`
+			: ''
+		log('result [once]', best as string)
+		updateStatus()
+	})
+	try {
+		await vocal.start()
+	} catch (e) {
+		log('error', String(e))
+	}
+	updateStatus()
+})
+
+$btnAbortSignal.addEventListener('click', async () => {
+	if (!vocal) return
+	const controller = new AbortController()
+	$abortInfo.textContent = 'Abort dans 3s...'
+	$btnAbortSignal.disabled = true
+
+	const timer = setTimeout(() => {
+		controller.abort()
+		$abortInfo.textContent = 'Aborted via AbortSignal.'
+		$btnAbortSignal.disabled = false
+		log('abort-signal', 'AbortController.abort() appelé après 3s')
+		updateStatus()
+	}, 3000)
+
+	try {
+		await vocal.start({ signal: controller.signal })
+	} catch (e) {
+		clearTimeout(timer)
+		$abortInfo.textContent = ''
+		$btnAbortSignal.disabled = false
+		log('error', String(e))
+	}
+	updateStatus()
+})
+
+$btnClearLog.addEventListener('click', () => {
+	$log.innerHTML = '<div class="log-empty">No events yet.</div>'
+})

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -139,6 +139,16 @@ function initVocal() {
 	updateStatus()
 }
 
+// ── Collapsible panels (force open on desktop) ────────────────────────────────
+
+function syncCollapsible() {
+	document.querySelectorAll<HTMLDetailsElement>('details.collapsible').forEach((el) => {
+		if (window.innerWidth > 768) el.open = true
+	})
+}
+syncCollapsible()
+window.addEventListener('resize', syncCollapsible)
+
 // ── Init ──────────────────────────────────────────────────────────────────────
 
 if (!Vocal.isSupported) {

--- a/demo/vite.config.js
+++ b/demo/vite.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from 'vite'
 
 export default defineConfig({
-	root: 'demo',
 	server: {
 		port: 3000,
 		open: true,

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"vitest": "^4.1.5"
 	},
 	"dependencies": {
-		"@untemps/user-permissions-utils": "^1.3.0"
+		"@untemps/user-permissions-utils": "1.3.3"
 	},
 	"release": {
 		"branches": [
@@ -104,7 +104,7 @@
 		]
 	},
 	"scripts": {
-		"dev": "vite --config vite.dev.config.js",
+		"dev": "vite demo --config demo/vite.config.js",
 		"test": "vitest",
 		"test:ci": "vitest run --coverage",
 		"build": "vite build",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"vitest": "^4.1.5"
 	},
 	"dependencies": {
-		"@untemps/user-permissions-utils": "1.3.3"
+		"@untemps/user-permissions-utils": "^1.3.3"
 	},
 	"release": {
 		"branches": [

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
 		]
 	},
 	"scripts": {
+		"dev": "vite --config vite.dev.config.js",
 		"test": "vitest",
 		"test:ci": "vitest run --coverage",
 		"build": "vite build",

--- a/vite.dev.config.js
+++ b/vite.dev.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+	root: 'demo',
+	server: {
+		port: 3000,
+		open: true,
+	},
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1200,10 +1200,10 @@
     "@typescript-eslint/types" "8.59.3"
     eslint-visitor-keys "^5.0.0"
 
-"@untemps/user-permissions-utils@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@untemps/user-permissions-utils/-/user-permissions-utils-1.3.0.tgz#1538b288309b81cd0535839c439d1e09c648325e"
-  integrity sha512-kSnu+0IO5W8a2Y27Li+eSd0OII6QnKAqQJAD08bmcMHzSQxKFjazyS5VRBezLa+rOBClYCr07nWyw24Pf/Py5Q==
+"@untemps/user-permissions-utils@1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@untemps/user-permissions-utils/-/user-permissions-utils-1.3.3.tgz#406b380bf2a38020ef679b19a3cd7fb070b3ca01"
+  integrity sha512-YYGwoVKRoGUI/Oo9ktMAfA8iHOI3WA9HMVRQGR24bwP7mNvC3Nn+BLfvyUE8uj7q6HAzIqLERUrSRDTPUMtpgw==
 
 "@vitest/coverage-v8@^4.1.5":
   version "4.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1200,7 +1200,7 @@
     "@typescript-eslint/types" "8.59.3"
     eslint-visitor-keys "^5.0.0"
 
-"@untemps/user-permissions-utils@1.3.3":
+"@untemps/user-permissions-utils@^1.3.3":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@untemps/user-permissions-utils/-/user-permissions-utils-1.3.3.tgz#406b380bf2a38020ef679b19a3cd7fb070b3ca01"
   integrity sha512-YYGwoVKRoGUI/Oo9ktMAfA8iHOI3WA9HMVRQGR24bwP7mNvC3Nn+BLfvyUE8uj7q6HAzIqLERUrSRDTPUMtpgw==


### PR DESCRIPTION
## Summary

- Add `demo/` folder with a vanilla HTML/TS dev page served by Vite
- Add `vite.dev.config.js` (root = `demo/`, port 3000) — séparé du lib build
- Add `yarn dev` script → `vite --config vite.dev.config.js`

## What the demo covers

- `Vocal.isSupported`, `isRecording`, instance status
- Options panel: `lang`, `maxAlternatives`, `continuous`, `interimResults` + reinitialise
- Controls: Start / Stop / Abort / Cleanup
- Events log: tous les events en temps réel avec color-coding
- `once()` demo: s'auto-désenregistre après le premier résultat
- AbortSignal demo: démarre et annule automatiquement après 3s

## Test plan

- [ ] `yarn dev` → http://localhost:3000 s'ouvre
- [ ] Tester Start / Stop / Abort
- [ ] Vérifier le log events
- [ ] Tester once() (un seul résultat attendu)
- [ ] Tester AbortSignal (annulation après 3s)
- [ ] Vérifier le panneau Status (`isRecording` toggle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)