### PR TITLE
refactor!: Remove once() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,22 +150,6 @@ Removes a listener for the given event type.
 
 Throws if `eventType` is not a valid `EventType`.
 
-### `once(eventType, callback)`
-
-Registers a one-shot listener that automatically unregisters itself after firing once.
-
-| Parameter | Type                                              | Description                                |
-| --------- | ------------------------------------------------- | ------------------------------------------ |
-| eventType | `EventType`                                       | One of the valid event type strings        |
-| callback  | `ResultEventHandler \| ErrorEventHandler \| GenericEventHandler` | Callback invoked once when the event fires |
-
-```js
-vocal.once('result', (event, bestAlternative, alternatives) => {
-    console.log(bestAlternative)
-    vocal.stop()
-})
-```
-
 ### `cleanup()`
 
 Stops recognition, removes all registered listeners, and releases the internal `SpeechRecognition` instance. The `Vocal` object cannot be reused after `cleanup()`.

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -266,15 +266,6 @@ class Vocal {
 		return this
 	}
 
-	once<T extends EventType>(eventType: T, callback: EventHandlerFor<T>): this
-	once(eventType: string, callback: EventHandler): this {
-		const wrapper: EventHandler = (...args) => {
-			;(callback as EventHandler).call(this, ...args)
-			this.removeEventListener(eventType as EventType, wrapper as EventHandlerFor<EventType>)
-		}
-		return this.addEventListener(eventType as EventType, wrapper as EventHandlerFor<EventType>)
-	}
-
 	cleanup(): this {
 		this.stop()
 

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -452,35 +452,6 @@ describe('Vocal', () => {
 		})
 	})
 
-	describe('once', () => {
-		it('fires callback only on the first event', () => {
-			const onStart = vi.fn()
-			const wrapper = new Vocal()
-			wrapper.once(Vocal.eventTypes.START, onStart)
-			mockInstance(wrapper).start()
-			mockInstance(wrapper).start()
-			expect(onStart).toHaveBeenCalledTimes(1)
-		})
-
-		it('removes the listener after first fire', () => {
-			const onStart = vi.fn()
-			const wrapper = new Vocal()
-			wrapper.once(Vocal.eventTypes.START, onStart)
-			mockInstance(wrapper).start()
-			expect(mockInstance(wrapper).removeEventListener).toHaveBeenCalled()
-		})
-
-		it('throws on invalid event types', () => {
-			const wrapper = new Vocal()
-			expect(() => wrapper.once('invalid-type', vi.fn())).toThrow('Unknown event type "invalid-type"')
-		})
-
-		it('returns this for chaining', () => {
-			const wrapper = new Vocal()
-			expect(wrapper.once(Vocal.eventTypes.START, vi.fn())).toBe(wrapper)
-		})
-	})
-
 	describe('continuous auto-restart', () => {
 		const fireEnd = (instance: MockInstance) => {
 			;(instance.addEventListener.mock.calls as [string, EventListener][])


### PR DESCRIPTION
## Summary

Removes the `once()` method from `Vocal`. The "register a one-shot listener, fire once, then unregister" pattern it served has been subsumed by #82, which now emits an aggregated `result` event on explicit `stop()` — so the typical use case (capture a single result then terminate) is covered by `addEventListener` alone.

## Changes

- Drop the `once()` overload + implementation in `src/Vocal.ts`
- Drop the `describe('once', ...)` block (4 tests) in `src/__tests__/Vocal.test.ts`
- Drop the `### once(eventType, callback)` section in `README.md`

## ⚠️ Breaking changes

- **`vocal.once(eventType, callback)`** is removed. Any consumer using it must migrate to a manual `addEventListener` + `removeEventListener` pair:

  ```js
  const handler = (event, best) => {
    vocal.removeEventListener('result', handler)
    // ...
  }
  vocal.addEventListener('result', handler)
  ```

## Test plan

- [ ] `yarn test:ci` — 84 tests pass (was 88), 100% coverage maintained
- [ ] `yarn lint && yarn typecheck && yarn build` — all green

Closes #85