### PR TITLE
refactor!: Move from class-based to functional API

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Throws if `eventType` is not a valid `EventType`.
 
 Stops recognition, removes all registered listeners, and releases the internal `SpeechRecognition` instance. The returned `VocalInstance` cannot be reused after `cleanup()`.
 
-## Migration from the class-based API
+## Migration from the class-based API (v1.x)
 
 ```js
 // Before

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @untemps/vocal
 
-Class wrapped around the SpeechRecognition Web API
+Functional wrapper around the SpeechRecognition Web API
 
 ![npm](https://img.shields.io/npm/v/@untemps/vocal?style=for-the-badge)
 ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/untemps/vocal/publish.yml?style=for-the-badge)
@@ -14,27 +14,22 @@ yarn add @untemps/vocal
 
 ## Basic Usage
 
-Import `Vocal` to a file.
-
 ```javascript
-import { Vocal } from '@untemps/vocal'
+import { createVocal, isSupported } from '@untemps/vocal'
 
 // Check whether SpeechRecognition, Permissions and MediaDevices interfaces are supported
-if (!Vocal.isSupported) {
+if (!isSupported()) {
   throw new Error('Vocal is not supported')
 }
 
 // Create a Vocal instance (see below for all available option properties)
-const options = {
-    lang: 'fr-FR',
-}
-const vocal = new Vocal(options)
+const vocal = createVocal({ lang: 'fr-FR' })
 
-// Subscribe to Vocal instance events (see below for all available events)
-vocal.addEventListener('speechstart', (event) => console.log('Vocal starts recording'))
-vocal.addEventListener('speechend', (event) => console.log('Vocal stops recording'))
-vocal.addEventListener('result', (event, bestAlternative, alternatives) => console.log('Vocal catches a result:', bestAlternative, alternatives))
-vocal.addEventListener('error', (event) => console.error(event.error, event.message))
+// Subscribe to instance events (see below for all available events)
+vocal.on('speechstart', (event) => console.log('Vocal starts recording'))
+vocal.on('speechend', (event) => console.log('Vocal stops recording'))
+vocal.on('result', (event, bestAlternative, alternatives) => console.log('Vocal catches a result:', bestAlternative, alternatives))
+vocal.on('error', (event) => console.error(event.error, event.message))
 
 // Start recording — rejects on error
 try {
@@ -49,7 +44,7 @@ vocal.stop()
 // Abort recording entirely
 vocal.abort()
 
-// Remove all attached listeners and delete the Vocal instance
+// Remove all attached listeners and release the internal SpeechRecognition instance
 vocal.cleanup()
 ```
 
@@ -97,16 +92,32 @@ Please refer to [this section](https://developer.mozilla.org/en-US/docs/Web/API/
 | speechstart | Fired when sound recognized by the recognition service as speech has been detected        |
 | start       | fired when the recognition service has begun listening to incoming audio                  |
 
-## Getters
+For convenience, `eventTypes` is exported as a constant map so consumers can reference type strings symbolically:
 
-| Getter      | Type                      | Description                                                                                                          |
-| ----------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| isSupported | boolean                   | Whether the current environment supports the SpeechRecognition Web API (static)                                      |
-| isRecording | boolean                   | Whether recognition is currently active — `true` after `start()`, `false` after `stop()`, `abort()`, or `end` event |
+```js
+import { eventTypes } from '@untemps/vocal'
+vocal.on(eventTypes.RESULT, handler)
+```
+
+## Top-level exports
+
+| Export        | Kind     | Description                                                                                                          |
+| ------------- | -------- | -------------------------------------------------------------------------------------------------------------------- |
+| `createVocal` | function | Factory that returns a `VocalInstance`. See [Methods](#methods).                                                     |
+| `isSupported` | function | Returns `true` if the current environment supports the SpeechRecognition Web API. Call it (it is **not** a getter).  |
+| `eventTypes`  | const    | Map of valid event type strings (e.g. `eventTypes.RESULT === 'result'`).                                             |
+
+## Instance getter
+
+| Getter      | Type      | Description                                                                                                          |
+| ----------- | --------- | -------------------------------------------------------------------------------------------------------------------- |
+| isRecording | boolean   | Whether recognition is currently active — `true` after `start()`, `false` after `stop()`, `abort()`, or `end` event |
 
 ## Methods
 
 ### `start({ signal? })`
+
+Starts recognition. Resolves once the engine is active. Rejects if microphone permission cannot be obtained.
 
 | Parameter | Type          | Default     | Description                                                                   |
 | --------- | ------------- | ----------- | ----------------------------------------------------------------------------- |
@@ -122,13 +133,13 @@ controller.abort()
 
 ### `stop()`
 
-Stops recognition gracefully, allowing the current audio to be processed before disconnecting. Sets `isRecording` to `false`.
+Stops recognition gracefully, allowing the current audio to be processed before disconnecting. Sets `isRecording` to `false`. In continuous mode, emits the aggregated `result` event just before `end`.
 
 ### `abort()`
 
-Stops recognition immediately without processing pending audio. Sets `isRecording` to `false`.
+Stops recognition immediately without processing pending audio. Sets `isRecording` to `false`. Discards any aggregated transcript without emitting.
 
-### `addEventListener(eventType, callback)`
+### `on(eventType, callback)`
 
 Registers a callback for the given event type. Multiple callbacks can be registered for the same type — they stack and all fire in registration order.
 
@@ -139,7 +150,7 @@ Registers a callback for the given event type. Multiple callbacks can be registe
 
 Throws if `eventType` is not a valid `EventType`.
 
-### `removeEventListener(eventType, callback?)`
+### `off(eventType, callback?)`
 
 Removes a listener for the given event type.
 
@@ -152,5 +163,24 @@ Throws if `eventType` is not a valid `EventType`.
 
 ### `cleanup()`
 
-Stops recognition, removes all registered listeners, and releases the internal `SpeechRecognition` instance. The `Vocal` object cannot be reused after `cleanup()`.
+Stops recognition, removes all registered listeners, and releases the internal `SpeechRecognition` instance. The returned `VocalInstance` cannot be reused after `cleanup()`.
 
+## Migration from the class-based API
+
+```js
+// Before
+import { Vocal } from '@untemps/vocal'
+if (!Vocal.isSupported) throw new Error()
+const vocal = new Vocal({ lang: 'fr-FR' })
+vocal.addEventListener('result', cb)
+vocal.removeEventListener('result', cb)
+
+// After
+import { createVocal, isSupported } from '@untemps/vocal'
+if (!isSupported()) throw new Error()
+const vocal = createVocal({ lang: 'fr-FR' })
+vocal.on('result', cb)
+vocal.off('result', cb)
+```
+
+Side-effect methods (`stop`, `abort`, `on`, `off`, `cleanup`) now return `void` — method chaining is no longer supported. `Vocal.eventTypes` is now exported as the top-level `eventTypes` const.

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -130,7 +130,9 @@ function initVocal() {
 		updateStatus()
 	})
 
-	vocal.on('nomatch', logEvent('nomatch'))
+	vocal.on('nomatch',     logEvent('nomatch'))
+	vocal.on('speechstart', logEvent('speechstart'))
+	vocal.on('speechend',   logEvent('speechend'))
 
 	log('init', JSON.stringify(options))
 	updateStatus()

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -130,15 +130,7 @@ function initVocal() {
 		updateStatus()
 	})
 
-	vocal.on('start',       logEvent('start'))
-	vocal.on('end',         logEvent('end'))
-	vocal.on('nomatch',     logEvent('nomatch'))
-	vocal.on('audiostart',  logEvent('audiostart'))
-	vocal.on('audioend',    logEvent('audioend'))
-	vocal.on('soundstart',  logEvent('soundstart'))
-	vocal.on('soundend',    logEvent('soundend'))
-	vocal.on('speechstart', logEvent('speechstart'))
-	vocal.on('speechend',   logEvent('speechend'))
+	vocal.on('nomatch', logEvent('nomatch'))
 
 	log('init', JSON.stringify(options))
 	updateStatus()

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -1,4 +1,4 @@
-import { Vocal } from '../src/index'
+import { createVocal, isSupported as isVocalSupported, type VocalInstance } from '../src/index'
 
 // ── DOM refs ──────────────────────────────────────────────────────────────────
 
@@ -23,8 +23,8 @@ const $btnClearLog = document.getElementById('btn-clear-log') as HTMLButtonEleme
 
 // ── State ─────────────────────────────────────────────────────────────────────
 
-const isSupported = Vocal.isSupported
-let vocal: Vocal | null = null
+const isSupported = isVocalSupported()
+let vocal: VocalInstance | null = null
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -116,30 +116,29 @@ function initVocal() {
 	}
 
 	const options = buildOptions()
-	vocal = new Vocal(options)
+	vocal = createVocal(options)
 
-	vocal.addEventListener('result', (_, best, alts) => {
-		$transcript.textContent = best as string
-		setAlternatives(alts as string[])
-		log('result', best as string)
+	vocal.on('result', (_, best, alts) => {
+		$transcript.textContent = best
+		setAlternatives(alts)
+		log('result', best)
 		updateStatus()
 	})
 
-	vocal.addEventListener('error', (e) => {
-		const err = e as SpeechRecognitionErrorEvent
-		log('error', err.error ?? String(e))
+	vocal.on('error', (event) => {
+		log('error', event.error ?? String(event))
 		updateStatus()
 	})
 
-	vocal.addEventListener('start',       logEvent('start'))
-	vocal.addEventListener('end',         logEvent('end'))
-	vocal.addEventListener('nomatch',     logEvent('nomatch'))
-	vocal.addEventListener('audiostart',  logEvent('audiostart'))
-	vocal.addEventListener('audioend',    logEvent('audioend'))
-	vocal.addEventListener('soundstart',  logEvent('soundstart'))
-	vocal.addEventListener('soundend',    logEvent('soundend'))
-	vocal.addEventListener('speechstart', logEvent('speechstart'))
-	vocal.addEventListener('speechend',   logEvent('speechend'))
+	vocal.on('start',       logEvent('start'))
+	vocal.on('end',         logEvent('end'))
+	vocal.on('nomatch',     logEvent('nomatch'))
+	vocal.on('audiostart',  logEvent('audiostart'))
+	vocal.on('audioend',    logEvent('audioend'))
+	vocal.on('soundstart',  logEvent('soundstart'))
+	vocal.on('soundend',    logEvent('soundend'))
+	vocal.on('speechstart', logEvent('speechstart'))
+	vocal.on('speechend',   logEvent('speechend'))
 
 	log('init', JSON.stringify(options))
 	updateStatus()

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -109,18 +109,18 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 	let isRestarting = false
 	let finalTranscripts: string[] = []
 
-	const resolved: Required<VocalOptions> = {
+	const resolvedOptions: Required<VocalOptions> = {
 		...defaultOptions,
 		...(options ?? {}),
 	}
 
-	instance.lang = resolved.lang
-	instance.continuous = resolved.continuous
-	instance.interimResults = resolved.interimResults
-	instance.maxAlternatives = resolved.maxAlternatives
+	instance.lang = resolvedOptions.lang
+	instance.continuous = resolvedOptions.continuous
+	instance.interimResults = resolvedOptions.interimResults
+	instance.maxAlternatives = resolvedOptions.maxAlternatives
 
-	if (resolved.grammars) {
-		instance.grammars = resolved.grammars
+	if (resolvedOptions.grammars) {
+		instance.grammars = resolvedOptions.grammars
 	} else {
 		const SpeechGrammarList = resolveSpeechGrammarList()
 		instance.grammars = SpeechGrammarList ? new SpeechGrammarList() : null
@@ -153,8 +153,8 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		if (transcripts.length === 0) return
 		if (!listeners[eventTypes.RESULT]?.length) return
 
-		const aggregated = transcripts.join(' ').trim()
-		const result = Object.assign([{ transcript: aggregated, confidence: 1 }], { isFinal: true })
+		const aggregatedTranscripts = transcripts.join(' ').trim()
+		const result = Object.assign([{ transcript: aggregatedTranscripts, confidence: 1 }], { isFinal: true })
 		const event = Object.assign(new Event(eventTypes.RESULT), {
 			resultIndex: 0,
 			results: [result],

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -213,6 +213,7 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		if (!instance) return
 		try {
 			const stream = (await getUserMediaStream('microphone', { audio: true }, { signal })) as MediaStream | null
+			if (signal?.aborted) return
 			if (!stream) {
 				throw new Error('Unable to retrieve the stream from media device')
 			}

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -12,7 +12,21 @@ export interface VocalOptions {
 	maxAlternatives?: number
 }
 
-export type EventType = (typeof Vocal.eventTypes)[keyof typeof Vocal.eventTypes]
+export const eventTypes = {
+	AUDIO_END: 'audioend',
+	AUDIO_START: 'audiostart',
+	END: 'end',
+	ERROR: 'error',
+	NO_MATCH: 'nomatch',
+	RESULT: 'result',
+	SOUND_END: 'soundend',
+	SOUND_START: 'soundstart',
+	SPEECH_END: 'speechend',
+	SPEECH_START: 'speechstart',
+	START: 'start',
+} as const
+
+export type EventType = (typeof eventTypes)[keyof typeof eventTypes]
 
 export type ResultEventHandler = (
 	event: SpeechRecognitionEvent,
@@ -28,326 +42,274 @@ export type EventHandlerFor<T extends EventType> = T extends 'result'
 		? ErrorEventHandler
 		: GenericEventHandler
 
+export interface VocalInstance {
+	readonly isRecording: boolean
+	start(options?: { signal?: AbortSignal }): Promise<void>
+	stop(): void
+	abort(): void
+	on<T extends EventType>(eventType: T, callback: EventHandlerFor<T>): void
+	on(eventType: string, callback: GenericEventHandler): void
+	off<T extends EventType>(eventType: T, callback?: EventHandlerFor<T>): void
+	off(eventType: string, callback?: GenericEventHandler): void
+	cleanup(): void
+}
+
 type EventHandler = (...args: unknown[]) => void
 
 const RESTART_THROTTLE_MS = 1000
 const FATAL_ERRORS: ReadonlySet<string> = new Set(['not-allowed', 'service-not-allowed', 'audio-capture'])
 
-class Vocal {
-	static defaultOptions: Required<VocalOptions> = {
-		grammars: null,
-		lang: 'en-US',
-		continuous: false,
-		interimResults: false,
-		maxAlternatives: 1,
+const defaultOptions: Required<VocalOptions> = {
+	grammars: null,
+	lang: 'en-US',
+	continuous: false,
+	interimResults: false,
+	maxAlternatives: 1,
+}
+
+const resolveSpeechRecognition = (): typeof SpeechRecognition | undefined => {
+	if (typeof window === 'undefined') return undefined
+	return (
+		window.SpeechRecognition ??
+		window.webkitSpeechRecognition ??
+		window.mozSpeechRecognition ??
+		window.msSpeechRecognition
+	)
+}
+
+const resolveSpeechGrammarList = (): typeof SpeechGrammarList | undefined =>
+	window.SpeechGrammarList ??
+	window.webkitSpeechGrammarList ??
+	window.mozSpeechGrammarList ??
+	window.msSpeechGrammarList
+
+const pickBestAlternative = <T extends { confidence?: number }>(alternatives: T[]): T =>
+	alternatives.reduce((a, b) => ((b.confidence ?? 0) > (a.confidence ?? 0) ? b : a))
+
+const includesEventType = (eventType: string): boolean => Object.values(eventTypes).includes(eventType as EventType)
+
+const unknownEventTypeMessage = (eventType: string): string =>
+	`Unknown event type "${eventType}". Valid types are: ${Object.values(eventTypes).join(', ')}.`
+
+export const isSupported = (): boolean =>
+	!!resolveSpeechRecognition() && !!isNavigatorPermissionsSupported() && !!isNavigatorMediaDevicesSupported()
+
+export const createVocal = (options?: VocalOptions): VocalInstance => {
+	const SpeechRecognition = resolveSpeechRecognition()
+	if (!SpeechRecognition) {
+		throw new DOMException('SpeechRecognition not supported', 'NOT_SUPPORTED_ERR')
 	}
 
-	static eventTypes = {
-		AUDIO_END: 'audioend',
-		AUDIO_START: 'audiostart',
-		END: 'end',
-		ERROR: 'error',
-		NO_MATCH: 'nomatch',
-		RESULT: 'result',
-		SOUND_END: 'soundend',
-		SOUND_START: 'soundstart',
-		SPEECH_END: 'speechend',
-		SPEECH_START: 'speechstart',
-		START: 'start',
-	} as const
+	let instance: SpeechRecognition | null = new SpeechRecognition()
+	const listeners: Record<string, Array<{ callback: EventHandler; handler: EventHandler }>> = {}
+	let isRecording = false
+	let explicitStop = false
+	let lastStartedAt = 0
+	let restartTimeoutId: ReturnType<typeof setTimeout> | null = null
+	let isRestarting = false
+	let finalTranscripts: string[] = []
 
-	static get isSupported(): boolean {
-		return (
-			!!Vocal._resolveSpeechRecognition() &&
-			!!isNavigatorPermissionsSupported() &&
-			!!isNavigatorMediaDevicesSupported()
-		)
+	const { grammars, ...rest }: Required<VocalOptions> = {
+		...defaultOptions,
+		...(options ?? {}),
 	}
 
-	static set isSupported(_: boolean) {
-		throw new Error('You cannot set isSupported directly.')
+	const target = instance as unknown as Record<string, unknown>
+	Object.assign(target, rest)
+
+	if (!grammars) {
+		const SpeechGrammarList = resolveSpeechGrammarList()
+		target.grammars = SpeechGrammarList ? new SpeechGrammarList() : null
+	} else {
+		target.grammars = grammars
 	}
 
-	private _instance: SpeechRecognition | null = null
-	private _listeners: Record<string, Array<{ callback: EventHandler; handler: EventHandler }>> = {}
-	private _isRecording: boolean = false
-	private _explicitStop: boolean = false
-	private _lastStartedAt: number = 0
-	private _restartTimeoutId: ReturnType<typeof setTimeout> | null = null
-	private _isRestarting: boolean = false
-	private _finalTranscripts: string[] = []
-
-	private _onEnd = (event: Event): void => {
-		if (this._shouldAutoRestart()) {
-			// Chrome enforces a ~7s silence timeout even with continuous=true; restart transparently.
-			const delay = Math.max(0, RESTART_THROTTLE_MS - (Date.now() - this._lastStartedAt))
-			this._isRestarting = true
-			this._restartTimeoutId = setTimeout(() => this._restart(), delay)
-			event.stopImmediatePropagation()
-			return
+	const clearRestartTimeout = (): void => {
+		if (restartTimeoutId !== null) {
+			clearTimeout(restartTimeoutId)
+			restartTimeoutId = null
 		}
-		this._isRecording = false
+		isRestarting = false
 	}
 
-	private _onStart = (event: Event): void => {
-		if (this._isRestarting) {
-			event.stopImmediatePropagation()
-			// Defer reset so user-side 'start' wrappers in the same tick still see the flag and swallow.
-			queueMicrotask(() => {
-				this._isRestarting = false
-			})
-		}
-	}
+	const shouldAutoRestart = (): boolean => !!instance && !explicitStop && instance.continuous
 
-	private _onError = (event: Event): void => {
-		if (FATAL_ERRORS.has((event as SpeechRecognitionErrorEvent).error)) {
-			this._explicitStop = true
-			this._clearRestartTimeout()
-			this._isRecording = false
-		}
-	}
-
-	private _onResult = (event: Event): void => {
-		const speechEvent = event as SpeechRecognitionEvent
-		const result = speechEvent.results?.[speechEvent.resultIndex]
-		if (!result?.isFinal) return
-		this._finalTranscripts.push(Vocal._pickBestAlternative(Array.from(result)).transcript)
-	}
-
-	constructor(options?: VocalOptions) {
-		const SpeechRecognition = Vocal._resolveSpeechRecognition()
-		if (!SpeechRecognition) {
-			throw new DOMException('SpeechRecognition not supported', 'NOT_SUPPORTED_ERR')
-		}
-
-		this._instance = new SpeechRecognition()
-
-		const { grammars, ...rest }: Required<VocalOptions> = {
-			...Vocal.defaultOptions,
-			...(options ?? {}),
-		}
-
-		const instance = this._instance as unknown as Record<string, unknown>
-		Object.assign(instance, rest)
-
-		if (!grammars) {
-			const SpeechGrammarList = Vocal._resolveSpeechGrammarList()
-			instance.grammars = SpeechGrammarList ? new SpeechGrammarList() : null
-		} else {
-			instance.grammars = grammars
-		}
-
-		this._instance.addEventListener(Vocal.eventTypes.END, this._onEnd)
-		this._instance.addEventListener(Vocal.eventTypes.START, this._onStart)
-		this._instance.addEventListener(Vocal.eventTypes.ERROR, this._onError)
-		this._instance.addEventListener(Vocal.eventTypes.RESULT, this._onResult)
-	}
-
-	get isRecording(): boolean {
-		return this._isRecording
-	}
-
-	set isRecording(_: boolean) {
-		throw new Error('You cannot set isRecording directly.')
-	}
-
-	async start({ signal }: { signal?: AbortSignal } = {}): Promise<this> {
-		if (this._instance) {
-			try {
-				const stream = (await getUserMediaStream(
-					'microphone',
-					{ audio: true },
-					{ signal }
-				)) as MediaStream | null
-				if (!stream) {
-					throw new Error('Unable to retrieve the stream from media device')
-				}
-				this._explicitStop = false
-				this._finalTranscripts = []
-				this._instance.start()
-				this._isRecording = true
-				this._lastStartedAt = Date.now()
-			} catch (error) {
-				if (error instanceof Error && error.name === 'AbortError') return this
-				throw error
-			}
-		}
-
-		return this
-	}
-
-	stop(): this {
-		if (this._instance) {
-			this._explicitStop = true
-			this._clearRestartTimeout()
-			this._emitAggregatedResult()
-			this._instance.stop()
-			this._isRecording = false
-		}
-
-		return this
-	}
-
-	abort(): this {
-		if (this._instance) {
-			this._explicitStop = true
-			this._clearRestartTimeout()
-			this._instance.abort()
-			this._isRecording = false
-			this._finalTranscripts = []
-		}
-
-		return this
-	}
-
-	addEventListener<T extends EventType>(eventType: T, callback: EventHandlerFor<T>): this
-	addEventListener(eventType: string, callback: EventHandler): this {
-		if (!this._includesEventType(eventType)) {
-			throw new Error(this._unknownEventTypeMessage(eventType))
-		}
-		if (this._instance) {
-			const handler: EventHandler = (event) => {
-				// Swallow intermediate end/start emitted by the silent auto-restart cycle.
-				if (
-					this._isRestarting &&
-					(eventType === Vocal.eventTypes.END || eventType === Vocal.eventTypes.START)
-				) {
-					return
-				}
-				const additionalArgs: unknown[] = []
-				if (eventType === Vocal.eventTypes.RESULT) {
-					const speechEvent = event as SpeechRecognitionEvent
-					if (speechEvent.results?.length > 0 && speechEvent.resultIndex < speechEvent.results.length) {
-						const alternatives = Array.from(speechEvent.results[speechEvent.resultIndex])
-						additionalArgs.push(
-							Vocal._pickBestAlternative(alternatives).transcript,
-							alternatives.map((a) => a.transcript)
-						)
-					}
-				}
-
-				;(callback as EventHandler).call(this, event, ...additionalArgs)
-			}
-			this._instance.addEventListener(eventType, handler as EventListener)
-
-			if (!this._listeners[eventType]) {
-				this._listeners[eventType] = []
-			}
-			this._listeners[eventType].push({ callback, handler })
-		}
-
-		return this
-	}
-
-	removeEventListener<T extends EventType>(eventType: T, callback?: EventHandlerFor<T>): this
-	removeEventListener(eventType: string, callback?: EventHandler): this {
-		if (!this._includesEventType(eventType)) {
-			throw new Error(this._unknownEventTypeMessage(eventType))
-		}
-		const instance = this._instance
-		if (instance && this._listeners[eventType]) {
-			if (callback !== undefined) {
-				const idx = this._listeners[eventType].findIndex((e) => e.callback === callback)
-				if (idx !== -1) {
-					instance.removeEventListener(eventType, this._listeners[eventType][idx].handler as EventListener)
-					this._listeners[eventType].splice(idx, 1)
-					if (this._listeners[eventType].length === 0) {
-						delete this._listeners[eventType]
-					}
-				}
-			} else {
-				this._listeners[eventType].forEach(({ handler }) =>
-					instance.removeEventListener(eventType, handler as EventListener)
-				)
-				delete this._listeners[eventType]
-			}
-		}
-
-		return this
-	}
-
-	cleanup(): this {
-		this.stop()
-
-		Object.keys(this._listeners).forEach((key) => this.removeEventListener(key as EventType))
-		this._instance?.removeEventListener(Vocal.eventTypes.END, this._onEnd)
-		this._instance?.removeEventListener(Vocal.eventTypes.START, this._onStart)
-		this._instance?.removeEventListener(Vocal.eventTypes.ERROR, this._onError)
-		this._instance?.removeEventListener(Vocal.eventTypes.RESULT, this._onResult)
-		this._instance = null
-
-		return this
-	}
-
-	private _restart = (): void => {
-		this._restartTimeoutId = null
+	const restart = (): void => {
+		restartTimeoutId = null
 		try {
-			this._instance!.start()
-			this._lastStartedAt = Date.now()
+			instance!.start()
+			lastStartedAt = Date.now()
 		} catch {
-			this._isRestarting = false
-			this._isRecording = false
+			isRestarting = false
+			isRecording = false
 		}
 	}
 
-	private _emitAggregatedResult(): void {
-		const transcripts = this._finalTranscripts
-		this._finalTranscripts = []
+	const emitAggregatedResult = (): void => {
+		const transcripts = finalTranscripts
+		finalTranscripts = []
 		if (transcripts.length === 0) return
 
 		const aggregated = transcripts.join(' ').trim()
 		const result = Object.assign([{ transcript: aggregated, confidence: 1 }], { isFinal: true })
-		const event = Object.assign(new Event(Vocal.eventTypes.RESULT), {
+		const event = Object.assign(new Event(eventTypes.RESULT), {
 			resultIndex: 0,
 			results: [result],
 		})
 
 		// Snapshot listeners to stay safe if a handler removes itself during dispatch.
-		;[...(this._listeners[Vocal.eventTypes.RESULT] ?? [])].forEach(({ handler }) => handler(event))
+		;[...(listeners[eventTypes.RESULT] ?? [])].forEach(({ handler }) => handler(event))
 	}
 
-	private static _pickBestAlternative<T extends { confidence?: number }>(alternatives: T[]): T {
-		return alternatives.reduce((a, b) => ((b.confidence ?? 0) > (a.confidence ?? 0) ? b : a))
-	}
-
-	private _shouldAutoRestart(): boolean {
-		return !!this._instance && !this._explicitStop && this._instance.continuous
-	}
-
-	private _clearRestartTimeout(): void {
-		if (this._restartTimeoutId !== null) {
-			clearTimeout(this._restartTimeoutId)
-			this._restartTimeoutId = null
+	const onEnd = (event: Event): void => {
+		if (shouldAutoRestart()) {
+			// Chrome enforces a ~7s silence timeout even with continuous=true; restart transparently.
+			const delay = Math.max(0, RESTART_THROTTLE_MS - (Date.now() - lastStartedAt))
+			isRestarting = true
+			restartTimeoutId = setTimeout(restart, delay)
+			event.stopImmediatePropagation()
+			return
 		}
-		this._isRestarting = false
+		isRecording = false
 	}
 
-	private _includesEventType(eventType: string): boolean {
-		return Object.values(Vocal.eventTypes).includes(eventType as EventType)
+	const onStart = (event: Event): void => {
+		if (isRestarting) {
+			event.stopImmediatePropagation()
+			// Defer reset so user-side 'start' wrappers in the same tick still see the flag and swallow.
+			queueMicrotask(() => {
+				isRestarting = false
+			})
+		}
 	}
 
-	private _unknownEventTypeMessage(eventType: string): string {
-		return `Unknown event type "${eventType}". Valid types are: ${Object.values(Vocal.eventTypes).join(', ')}.`
+	const onError = (event: Event): void => {
+		if (FATAL_ERRORS.has((event as SpeechRecognitionErrorEvent).error)) {
+			explicitStop = true
+			clearRestartTimeout()
+			isRecording = false
+		}
 	}
 
-	private static _resolveSpeechRecognition(): typeof SpeechRecognition | undefined {
-		if (typeof window === 'undefined') return undefined
-		return (
-			window.SpeechRecognition ??
-			window.webkitSpeechRecognition ??
-			window.mozSpeechRecognition ??
-			window.msSpeechRecognition
-		)
+	const onResult = (event: Event): void => {
+		const speechEvent = event as SpeechRecognitionEvent
+		const result = speechEvent.results?.[speechEvent.resultIndex]
+		if (!result?.isFinal) return
+		finalTranscripts.push(pickBestAlternative(Array.from(result)).transcript)
 	}
 
-	private static _resolveSpeechGrammarList(): typeof SpeechGrammarList | undefined {
-		return (
-			window.SpeechGrammarList ??
-			window.webkitSpeechGrammarList ??
-			window.mozSpeechGrammarList ??
-			window.msSpeechGrammarList
-		)
+	instance.addEventListener(eventTypes.END, onEnd)
+	instance.addEventListener(eventTypes.START, onStart)
+	instance.addEventListener(eventTypes.ERROR, onError)
+	instance.addEventListener(eventTypes.RESULT, onResult)
+
+	const start = async ({ signal }: { signal?: AbortSignal } = {}): Promise<void> => {
+		if (!instance) return
+		try {
+			const stream = (await getUserMediaStream('microphone', { audio: true }, { signal })) as MediaStream | null
+			if (!stream) {
+				throw new Error('Unable to retrieve the stream from media device')
+			}
+			explicitStop = false
+			finalTranscripts = []
+			instance.start()
+			isRecording = true
+			lastStartedAt = Date.now()
+		} catch (error) {
+			if (error instanceof Error && error.name === 'AbortError') return
+			throw error
+		}
+	}
+
+	const stop = (): void => {
+		if (!instance) return
+		explicitStop = true
+		clearRestartTimeout()
+		emitAggregatedResult()
+		instance.stop()
+		isRecording = false
+	}
+
+	const abort = (): void => {
+		if (!instance) return
+		explicitStop = true
+		clearRestartTimeout()
+		instance.abort()
+		isRecording = false
+		finalTranscripts = []
+	}
+
+	const on = (eventType: string, callback: EventHandler): void => {
+		if (!includesEventType(eventType)) {
+			throw new Error(unknownEventTypeMessage(eventType))
+		}
+		if (!instance) return
+
+		const handler: EventHandler = (event) => {
+			if (isRestarting && (eventType === eventTypes.END || eventType === eventTypes.START)) {
+				return
+			}
+			const additionalArgs: unknown[] = []
+			if (eventType === eventTypes.RESULT) {
+				const speechEvent = event as SpeechRecognitionEvent
+				if (speechEvent.results?.length > 0 && speechEvent.resultIndex < speechEvent.results.length) {
+					const alternatives = Array.from(speechEvent.results[speechEvent.resultIndex])
+					additionalArgs.push(
+						pickBestAlternative(alternatives).transcript,
+						alternatives.map((a) => a.transcript)
+					)
+				}
+			}
+			callback(event, ...additionalArgs)
+		}
+		instance.addEventListener(eventType, handler as EventListener)
+
+		if (!listeners[eventType]) listeners[eventType] = []
+		listeners[eventType].push({ callback, handler })
+	}
+
+	const off = (eventType: string, callback?: EventHandler): void => {
+		if (!includesEventType(eventType)) {
+			throw new Error(unknownEventTypeMessage(eventType))
+		}
+		if (!instance || !listeners[eventType]) return
+
+		if (callback !== undefined) {
+			const idx = listeners[eventType].findIndex((e) => e.callback === callback)
+			if (idx !== -1) {
+				instance.removeEventListener(eventType, listeners[eventType][idx].handler as EventListener)
+				listeners[eventType].splice(idx, 1)
+				if (listeners[eventType].length === 0) {
+					delete listeners[eventType]
+				}
+			}
+		} else {
+			listeners[eventType].forEach(({ handler }) =>
+				instance!.removeEventListener(eventType, handler as EventListener)
+			)
+			delete listeners[eventType]
+		}
+	}
+
+	const cleanup = (): void => {
+		stop()
+		Object.keys(listeners).forEach((key) => off(key))
+		instance?.removeEventListener(eventTypes.END, onEnd)
+		instance?.removeEventListener(eventTypes.START, onStart)
+		instance?.removeEventListener(eventTypes.ERROR, onError)
+		instance?.removeEventListener(eventTypes.RESULT, onResult)
+		instance = null
+	}
+
+	return {
+		get isRecording() {
+			return isRecording
+		},
+		start,
+		stop,
+		abort,
+		on: on as VocalInstance['on'],
+		off: off as VocalInstance['off'],
+		cleanup,
 	}
 }
-
-export default Vocal

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -109,19 +109,21 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 	let isRestarting = false
 	let finalTranscripts: string[] = []
 
-	const { grammars, ...rest }: Required<VocalOptions> = {
+	const resolved: Required<VocalOptions> = {
 		...defaultOptions,
 		...(options ?? {}),
 	}
 
-	const target = instance as unknown as Record<string, unknown>
-	Object.assign(target, rest)
+	instance.lang = resolved.lang
+	instance.continuous = resolved.continuous
+	instance.interimResults = resolved.interimResults
+	instance.maxAlternatives = resolved.maxAlternatives
 
-	if (!grammars) {
-		const SpeechGrammarList = resolveSpeechGrammarList()
-		target.grammars = SpeechGrammarList ? new SpeechGrammarList() : null
+	if (resolved.grammars) {
+		instance.grammars = resolved.grammars
 	} else {
-		target.grammars = grammars
+		const SpeechGrammarList = resolveSpeechGrammarList()
+		instance.grammars = SpeechGrammarList ? new SpeechGrammarList() : null
 	}
 
 	const clearRestartTimeout = (): void => {
@@ -149,6 +151,7 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		const transcripts = finalTranscripts
 		finalTranscripts = []
 		if (transcripts.length === 0) return
+		if (!listeners[eventTypes.RESULT]?.length) return
 
 		const aggregated = transcripts.join(' ').trim()
 		const result = Object.assign([{ transcript: aggregated, confidence: 1 }], { isFinal: true })
@@ -158,7 +161,7 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		})
 
 		// Snapshot listeners to stay safe if a handler removes itself during dispatch.
-		;[...(listeners[eventTypes.RESULT] ?? [])].forEach(({ handler }) => handler(event))
+		;[...listeners[eventTypes.RESULT]].forEach(({ handler }) => handler(event))
 	}
 
 	const onEnd = (event: Event): void => {
@@ -198,10 +201,13 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		finalTranscripts.push(pickBestAlternative(Array.from(result)).transcript)
 	}
 
-	instance.addEventListener(eventTypes.END, onEnd)
-	instance.addEventListener(eventTypes.START, onStart)
-	instance.addEventListener(eventTypes.ERROR, onError)
-	instance.addEventListener(eventTypes.RESULT, onResult)
+	const internalListeners: Array<[EventType, EventListener]> = [
+		[eventTypes.END, onEnd],
+		[eventTypes.START, onStart],
+		[eventTypes.ERROR, onError],
+		[eventTypes.RESULT, onResult],
+	]
+	internalListeners.forEach(([type, handler]) => instance!.addEventListener(type, handler))
 
 	const start = async ({ signal }: { signal?: AbortSignal } = {}): Promise<void> => {
 		if (!instance) return
@@ -249,18 +255,21 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 			if (isRestarting && (eventType === eventTypes.END || eventType === eventTypes.START)) {
 				return
 			}
-			const additionalArgs: unknown[] = []
-			if (eventType === eventTypes.RESULT) {
-				const speechEvent = event as SpeechRecognitionEvent
-				if (speechEvent.results?.length > 0 && speechEvent.resultIndex < speechEvent.results.length) {
-					const alternatives = Array.from(speechEvent.results[speechEvent.resultIndex])
-					additionalArgs.push(
-						pickBestAlternative(alternatives).transcript,
-						alternatives.map((a) => a.transcript)
-					)
-				}
+			if (eventType !== eventTypes.RESULT) {
+				callback(event)
+				return
 			}
-			callback(event, ...additionalArgs)
+			const speechEvent = event as SpeechRecognitionEvent
+			if (!(speechEvent.results?.length > 0) || speechEvent.resultIndex >= speechEvent.results.length) {
+				callback(event)
+				return
+			}
+			const alternatives = Array.from(speechEvent.results[speechEvent.resultIndex])
+			callback(
+				event,
+				pickBestAlternative(alternatives).transcript,
+				alternatives.map((a) => a.transcript)
+			)
 		}
 		instance.addEventListener(eventType, handler as EventListener)
 
@@ -294,10 +303,7 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 	const cleanup = (): void => {
 		stop()
 		Object.keys(listeners).forEach((key) => off(key))
-		instance?.removeEventListener(eventTypes.END, onEnd)
-		instance?.removeEventListener(eventTypes.START, onStart)
-		instance?.removeEventListener(eventTypes.ERROR, onError)
-		instance?.removeEventListener(eventTypes.RESULT, onResult)
+		internalListeners.forEach(([type, handler]) => instance?.removeEventListener(type, handler))
 		instance = null
 	}
 

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -1,4 +1,4 @@
-import Vocal from '../Vocal'
+import { createVocal, isSupported, eventTypes, type VocalInstance } from '../Vocal'
 import * as userPermissionsUtils from '@untemps/user-permissions-utils'
 
 type MockFn = {
@@ -9,7 +9,9 @@ type MockFn = {
 type SayAlternative = string | { transcript: string; confidence: number }
 
 interface MockInstance {
-	say: ((sentence: string, alternatives?: SayAlternative[]) => void) & { mock: { calls: unknown[][] } }
+	say: ((sentence: string, alternatives?: SayAlternative[], options?: { isFinal?: boolean }) => void) & {
+		mock: { calls: unknown[][] }
+	}
 	addEventListener: MockFn
 	removeEventListener: MockFn
 	start: MockFn
@@ -18,28 +20,33 @@ interface MockInstance {
 	[key: string]: unknown
 }
 
-const mockInstance = (wrapper: Vocal) => (wrapper as unknown as { _instance: MockInstance })._instance
+const lastInstance = (): MockInstance => {
+	const sr = SpeechRecognition as unknown as { mock: { results: Array<{ value: MockInstance }> } }
+	return sr.mock.results[sr.mock.results.length - 1].value
+}
+
+const setup = (options?: Parameters<typeof createVocal>[0]): { vocal: VocalInstance; instance: MockInstance } => {
+	const vocal = createVocal(options)
+	return { vocal, instance: lastInstance() }
+}
+
 const mockStream = 'stream' as unknown as MediaStream
 const mockNull = null as unknown as MediaStream
 
 describe('Vocal', () => {
 	describe('isSupported', () => {
 		it('returns true when SpeechRecognition, permissions and mediaDevices are all supported', () => {
-			expect(Vocal.isSupported).toBe(true)
+			expect(isSupported()).toBe(true)
 		})
 
 		it('returns false when navigator.permissions is not supported', () => {
 			vi.spyOn(userPermissionsUtils, 'isNavigatorPermissionsSupported').mockReturnValueOnce(false)
-			expect(Vocal.isSupported).toBe(false)
+			expect(isSupported()).toBe(false)
 		})
 
 		it('returns false when navigator.mediaDevices is not supported', () => {
 			vi.spyOn(userPermissionsUtils, 'isNavigatorMediaDevicesSupported').mockReturnValueOnce(false)
-			expect(Vocal.isSupported).toBe(false)
-		})
-
-		it('throws when setting isSupported directly', () => {
-			expect(() => (Vocal.isSupported = false)).toThrow()
+			expect(isSupported()).toBe(false)
 		})
 
 		describe('when SpeechRecognition is unavailable', () => {
@@ -53,7 +60,7 @@ describe('Vocal', () => {
 			})
 
 			it('returns false', () => {
-				expect(Vocal.isSupported).toBe(false)
+				expect(isSupported()).toBe(false)
 			})
 		})
 
@@ -68,36 +75,36 @@ describe('Vocal', () => {
 			})
 
 			it('returns false without throwing', () => {
-				expect(() => Vocal.isSupported).not.toThrow()
-				expect(Vocal.isSupported).toBe(false)
+				expect(() => isSupported()).not.toThrow()
+				expect(isSupported()).toBe(false)
 			})
 		})
 	})
 
-	describe('constructor', () => {
+	describe('createVocal', () => {
 		it('applies default options', () => {
-			const wrapper = new Vocal()
-			expect(mockInstance(wrapper).lang).toBe('en-US')
-			expect(mockInstance(wrapper).continuous).toBe(false)
-			expect(mockInstance(wrapper).interimResults).toBe(false)
-			expect(mockInstance(wrapper).maxAlternatives).toBe(1)
+			const { instance } = setup()
+			expect(instance.lang).toBe('en-US')
+			expect(instance.continuous).toBe(false)
+			expect(instance.interimResults).toBe(false)
+			expect(instance.maxAlternatives).toBe(1)
 		})
 
 		it('applies custom options', () => {
-			const wrapper = new Vocal({ lang: 'fr-FR', continuous: true })
-			expect(mockInstance(wrapper).lang).toBe('fr-FR')
-			expect(mockInstance(wrapper).continuous).toBe(true)
+			const { instance } = setup({ lang: 'fr-FR', continuous: true })
+			expect(instance.lang).toBe('fr-FR')
+			expect(instance.continuous).toBe(true)
 		})
 
 		it('assigns SpeechGrammarList instance when grammars is null and SpeechGrammarList is available', () => {
-			const wrapper = new Vocal()
-			expect(mockInstance(wrapper).grammars).not.toBeNull()
+			const { instance } = setup()
+			expect(instance.grammars).not.toBeNull()
 		})
 
 		it('uses provided grammars value when non-null', () => {
 			const grammars = { items: [] } as unknown as SpeechGrammarList
-			const wrapper = new Vocal({ grammars })
-			expect(mockInstance(wrapper).grammars).toBe(grammars)
+			const { instance } = setup({ grammars })
+			expect(instance.grammars).toBe(grammars)
 		})
 
 		describe('when SpeechRecognition is unavailable', () => {
@@ -111,7 +118,7 @@ describe('Vocal', () => {
 			})
 
 			it('throws DOMException', () => {
-				expect(() => new Vocal()).toThrow(DOMException)
+				expect(() => createVocal()).toThrow(DOMException)
 			})
 		})
 
@@ -126,65 +133,60 @@ describe('Vocal', () => {
 			})
 
 			it('leaves grammars null', () => {
-				const wrapper = new Vocal()
-				expect(mockInstance(wrapper).grammars).toBeNull()
+				const { instance } = setup()
+				expect(instance.grammars).toBeNull()
 			})
 		})
 	})
 
 	describe('isRecording', () => {
 		it('returns false by default', () => {
-			const wrapper = new Vocal()
-			expect(wrapper.isRecording).toBe(false)
+			const { vocal } = setup()
+			expect(vocal.isRecording).toBe(false)
 		})
 
 		it('returns true after a successful start', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal()
-			await wrapper.start()
-			expect(wrapper.isRecording).toBe(true)
+			const { vocal } = setup()
+			await vocal.start()
+			expect(vocal.isRecording).toBe(true)
 		})
 
 		it.each([
-			['stop', (w: Vocal) => w.stop()],
-			['abort', (w: Vocal) => w.abort()],
+			['stop', (v: VocalInstance) => v.stop()],
+			['abort', (v: VocalInstance) => v.abort()],
 		] as const)('returns false after %s', async (_, action) => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal()
-			await wrapper.start()
-			action(wrapper)
-			expect(wrapper.isRecording).toBe(false)
+			const { vocal } = setup()
+			await vocal.start()
+			action(vocal)
+			expect(vocal.isRecording).toBe(false)
 		})
 
 		it('returns false when end event fires', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal()
-			await wrapper.start()
-			mockInstance(wrapper)
-				.addEventListener.mock.calls.filter(([type]: string[]) => type === 'end')
+			const { vocal, instance } = setup()
+			await vocal.start()
+			instance.addEventListener.mock.calls
+				.filter(([type]: string[]) => type === 'end')
 				.forEach(([, handler]: [string, EventListener]) => handler(new Event('end')))
-			expect(wrapper.isRecording).toBe(false)
-		})
-
-		it('throws when setting isRecording directly', () => {
-			const wrapper = new Vocal()
-			expect(() => (wrapper.isRecording = true)).toThrow()
+			expect(vocal.isRecording).toBe(false)
 		})
 	})
 
 	describe('start', () => {
 		it('calls instance.start when getUserMediaStream returns a stream', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal()
-			await wrapper.start()
-			expect(mockInstance(wrapper).start).toHaveBeenCalled()
+			const { vocal, instance } = setup()
+			await vocal.start()
+			expect(instance.start).toHaveBeenCalled()
 		})
 
 		it('rejects when getUserMediaStream returns null', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockNull)
-			const wrapper = new Vocal()
-			await expect(wrapper.start()).rejects.toThrow('Unable to retrieve the stream from media device')
-			expect(wrapper.isRecording).toBe(false)
+			const { vocal } = setup()
+			await expect(vocal.start()).rejects.toThrow('Unable to retrieve the stream from media device')
+			expect(vocal.isRecording).toBe(false)
 		})
 
 		it('rejects when getUserMediaStream throws', async () => {
@@ -192,119 +194,103 @@ describe('Vocal', () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockImplementationOnce(() => {
 				throw error
 			})
-			const wrapper = new Vocal()
-			await expect(wrapper.start()).rejects.toThrow(error)
-			expect(wrapper.isRecording).toBe(false)
+			const { vocal } = setup()
+			await expect(vocal.start()).rejects.toThrow(error)
+			expect(vocal.isRecording).toBe(false)
 		})
 
-		it('does nothing when instance is null', async () => {
-			const wrapper = new Vocal()
-			const instance = mockInstance(wrapper)
-			wrapper.cleanup()
-			await wrapper.start()
-			expect(instance.start).not.toHaveBeenCalled()
-		})
-
-		it('returns this for chaining', async () => {
-			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal()
-			expect(await wrapper.start()).toBe(wrapper)
+		it('does nothing once cleaned up', async () => {
+			const { vocal, instance } = setup()
+			vocal.cleanup()
+			const startCallsBefore = (instance.start as MockFn).mock.calls.length
+			await vocal.start()
+			expect((instance.start as MockFn).mock.calls.length).toBe(startCallsBefore)
 		})
 
 		it('resolves when getUserMediaStream is aborted', async () => {
 			const abortError = Object.assign(new Error('Aborted'), { name: 'AbortError' })
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockRejectedValueOnce(abortError)
-			const wrapper = new Vocal()
-			await expect(wrapper.start()).resolves.toBe(wrapper)
+			const { vocal } = setup()
+			await expect(vocal.start()).resolves.toBeUndefined()
 		})
 
 		it('forwards signal to getUserMediaStream when provided', async () => {
 			const spy = vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
 			const signal = new AbortController().signal
-			const wrapper = new Vocal()
-			await wrapper.start({ signal })
+			const { vocal } = setup()
+			await vocal.start({ signal })
 			expect(spy).toHaveBeenCalledWith('microphone', { audio: true }, { signal })
 		})
 
 		it('calls getUserMediaStream without signal when not provided', async () => {
 			const spy = vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal()
-			await wrapper.start()
+			const { vocal } = setup()
+			await vocal.start()
 			expect(spy).toHaveBeenCalledWith('microphone', { audio: true }, { signal: undefined })
 		})
 	})
 
 	describe('stop', () => {
 		it('calls instance.stop', () => {
-			const wrapper = new Vocal()
-			wrapper.stop()
-			expect(mockInstance(wrapper).stop).toHaveBeenCalled()
+			const { vocal, instance } = setup()
+			vocal.stop()
+			expect(instance.stop).toHaveBeenCalled()
 		})
 
-		it('returns this for chaining', () => {
-			const wrapper = new Vocal()
-			expect(wrapper.stop()).toBe(wrapper)
-		})
-
-		it('does nothing when instance is null', () => {
-			const wrapper = new Vocal()
-			wrapper.cleanup()
-			expect(() => wrapper.stop()).not.toThrow()
+		it('does nothing once cleaned up', () => {
+			const { vocal } = setup()
+			vocal.cleanup()
+			expect(() => vocal.stop()).not.toThrow()
 		})
 	})
 
 	describe('abort', () => {
 		it('calls instance.abort', () => {
-			const wrapper = new Vocal()
-			wrapper.abort()
-			expect(mockInstance(wrapper).abort).toHaveBeenCalled()
+			const { vocal, instance } = setup()
+			vocal.abort()
+			expect(instance.abort).toHaveBeenCalled()
 		})
 
-		it('returns this for chaining', () => {
-			const wrapper = new Vocal()
-			expect(wrapper.abort()).toBe(wrapper)
-		})
-
-		it('does nothing when instance is null', () => {
-			const wrapper = new Vocal()
-			wrapper.cleanup()
-			expect(() => wrapper.abort()).not.toThrow()
+		it('does nothing once cleaned up', () => {
+			const { vocal } = setup()
+			vocal.cleanup()
+			expect(() => vocal.abort()).not.toThrow()
 		})
 	})
 
-	describe('addEventListener', () => {
+	describe('on', () => {
 		it('registers and calls callback for non-RESULT events', () => {
 			const onStart = vi.fn()
-			const wrapper = new Vocal()
-			wrapper.addEventListener(Vocal.eventTypes.START, onStart)
-			mockInstance(wrapper).start()
+			const { vocal, instance } = setup()
+			vocal.on(eventTypes.START, onStart)
+			instance.start()
 			expect(onStart).toHaveBeenCalled()
 		})
 
 		it('passes best transcript and alternatives array for RESULT events', () => {
 			const onResult = vi.fn()
-			const wrapper = new Vocal()
-			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
-			mockInstance(wrapper).say('hello world')
+			const { vocal, instance } = setup()
+			vocal.on(eventTypes.RESULT, onResult)
+			instance.say('hello world')
 			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'hello world', ['hello world'])
 		})
 
 		it('passes all alternatives when multiple are available', () => {
 			const onResult = vi.fn()
-			const wrapper = new Vocal()
-			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
-			mockInstance(wrapper).say('hello', ['hello', 'helo', 'hell'])
+			const { vocal, instance } = setup()
+			vocal.on(eventTypes.RESULT, onResult)
+			instance.say('hello', ['hello', 'helo', 'hell'])
 			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'hello', ['hello', 'helo', 'hell'])
 		})
 
 		it('falls back to first alternative when confidence is unavailable', () => {
 			const onResult = vi.fn()
-			const wrapper = new Vocal()
-			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
-			const [, handler] = (mockInstance(wrapper).addEventListener.mock.calls as string[][]).findLast(
-				([type]) => type === Vocal.eventTypes.RESULT
+			const { vocal, instance } = setup()
+			vocal.on(eventTypes.RESULT, onResult)
+			const [, handler] = (instance.addEventListener.mock.calls as string[][]).findLast(
+				([type]) => type === eventTypes.RESULT
 			)!
-			const event = Object.assign(new Event(Vocal.eventTypes.RESULT), {
+			const event = Object.assign(new Event(eventTypes.RESULT), {
 				resultIndex: 0,
 				results: [[{ transcript: 'hello' }, { transcript: 'helo' }, { transcript: 'hell' }]],
 			})
@@ -314,9 +300,9 @@ describe('Vocal', () => {
 
 		it('selects the alternative with highest confidence as best transcript', () => {
 			const onResult = vi.fn()
-			const wrapper = new Vocal()
-			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
-			mockInstance(wrapper).say('helo', [
+			const { vocal, instance } = setup()
+			vocal.on(eventTypes.RESULT, onResult)
+			instance.say('helo', [
 				{ transcript: 'hello', confidence: 0.7 },
 				{ transcript: 'helo', confidence: 0.9 },
 				{ transcript: 'hell', confidence: 0.5 },
@@ -326,12 +312,12 @@ describe('Vocal', () => {
 
 		it('uses resultIndex to select the current result in continuous mode', () => {
 			const onResult = vi.fn()
-			const wrapper = new Vocal()
-			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
-			const [, handler] = (mockInstance(wrapper).addEventListener.mock.calls as string[][]).findLast(
-				([type]) => type === Vocal.eventTypes.RESULT
+			const { vocal, instance } = setup()
+			vocal.on(eventTypes.RESULT, onResult)
+			const [, handler] = (instance.addEventListener.mock.calls as string[][]).findLast(
+				([type]) => type === eventTypes.RESULT
 			)!
-			const event = Object.assign(new Event(Vocal.eventTypes.RESULT), {
+			const event = Object.assign(new Event(eventTypes.RESULT), {
 				resultIndex: 1,
 				results: [
 					[{ transcript: 'first utterance', confidence: 0.9 }],
@@ -344,12 +330,12 @@ describe('Vocal', () => {
 
 		it('does not pass transcript when resultIndex is out of bounds', () => {
 			const onResult = vi.fn()
-			const wrapper = new Vocal()
-			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
-			const [, handler] = (mockInstance(wrapper).addEventListener.mock.calls as string[][]).findLast(
-				([type]) => type === Vocal.eventTypes.RESULT
+			const { vocal, instance } = setup()
+			vocal.on(eventTypes.RESULT, onResult)
+			const [, handler] = (instance.addEventListener.mock.calls as string[][]).findLast(
+				([type]) => type === eventTypes.RESULT
 			)!
-			const event = Object.assign(new Event(Vocal.eventTypes.RESULT), {
+			const event = Object.assign(new Event(eventTypes.RESULT), {
 				resultIndex: 5,
 				results: [[{ transcript: 'hello', confidence: 0.9 }]],
 			})
@@ -360,12 +346,12 @@ describe('Vocal', () => {
 
 		it('does not pass transcript for RESULT events with empty results', () => {
 			const onResult = vi.fn()
-			const wrapper = new Vocal()
-			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
-			const [, handler] = (mockInstance(wrapper).addEventListener.mock.calls as string[][]).findLast(
-				([type]) => type === Vocal.eventTypes.RESULT
+			const { vocal, instance } = setup()
+			vocal.on(eventTypes.RESULT, onResult)
+			const [, handler] = (instance.addEventListener.mock.calls as string[][]).findLast(
+				([type]) => type === eventTypes.RESULT
 			)!
-			const event = Object.assign(new Event(Vocal.eventTypes.RESULT), { results: [] })
+			const event = Object.assign(new Event(eventTypes.RESULT), { results: [] })
 			;(handler as unknown as (e: Event) => void)(event)
 			expect(onResult).toHaveBeenCalledTimes(1)
 			expect(onResult.mock.calls[0]).toHaveLength(1)
@@ -374,10 +360,10 @@ describe('Vocal', () => {
 		it('stacks multiple listeners for the same event type', () => {
 			const onStart1 = vi.fn()
 			const onStart2 = vi.fn()
-			const wrapper = new Vocal()
-			wrapper.addEventListener(Vocal.eventTypes.START, onStart1)
-			wrapper.addEventListener(Vocal.eventTypes.START, onStart2)
-			mockInstance(wrapper).start()
+			const { vocal, instance } = setup()
+			vocal.on(eventTypes.START, onStart1)
+			vocal.on(eventTypes.START, onStart2)
+			instance.start()
 			expect(onStart1).toHaveBeenCalled()
 			expect(onStart2).toHaveBeenCalled()
 		})
@@ -385,69 +371,58 @@ describe('Vocal', () => {
 		it('removes a specific listener by callback reference', () => {
 			const onStart1 = vi.fn()
 			const onStart2 = vi.fn()
-			const wrapper = new Vocal()
-			wrapper.addEventListener(Vocal.eventTypes.START, onStart1)
-			wrapper.addEventListener(Vocal.eventTypes.START, onStart2)
-			wrapper.removeEventListener(Vocal.eventTypes.START, onStart1)
-			mockInstance(wrapper).start()
+			const { vocal, instance } = setup()
+			vocal.on(eventTypes.START, onStart1)
+			vocal.on(eventTypes.START, onStart2)
+			vocal.off(eventTypes.START, onStart1)
+			instance.start()
 			expect(onStart1).not.toHaveBeenCalled()
 			expect(onStart2).toHaveBeenCalled()
 		})
 
 		it('throws on invalid event types', () => {
-			const wrapper = new Vocal()
-			expect(() => wrapper.addEventListener('invalid-type', vi.fn())).toThrow('Unknown event type "invalid-type"')
+			const { vocal } = setup()
+			expect(() => vocal.on('invalid-type', vi.fn())).toThrow('Unknown event type "invalid-type"')
 		})
 
-		it('returns this for chaining', () => {
-			const wrapper = new Vocal()
-			expect(wrapper.addEventListener(Vocal.eventTypes.START, vi.fn())).toBe(wrapper)
-		})
-
-		it('does nothing when instance is null', () => {
-			const wrapper = new Vocal()
-			wrapper.cleanup()
-			expect(() => wrapper.addEventListener(Vocal.eventTypes.START, vi.fn())).not.toThrow()
+		it('does nothing once cleaned up', () => {
+			const { vocal } = setup()
+			vocal.cleanup()
+			expect(() => vocal.on(eventTypes.START, vi.fn())).not.toThrow()
 		})
 	})
 
-	describe('removeEventListener', () => {
+	describe('off', () => {
 		it('calls removeEventListener on the underlying instance', () => {
-			const wrapper = new Vocal()
-			wrapper.addEventListener(Vocal.eventTypes.START, vi.fn())
-			wrapper.removeEventListener(Vocal.eventTypes.START)
-			expect(mockInstance(wrapper).removeEventListener).toHaveBeenCalled()
+			const { vocal, instance } = setup()
+			vocal.on(eventTypes.START, vi.fn())
+			vocal.off(eventTypes.START)
+			expect(instance.removeEventListener).toHaveBeenCalled()
 		})
 
-		it('returns this for chaining', () => {
-			const wrapper = new Vocal()
-			wrapper.addEventListener(Vocal.eventTypes.START, vi.fn())
-			expect(wrapper.removeEventListener(Vocal.eventTypes.START)).toBe(wrapper)
-		})
-
-		it('does nothing when instance is null', () => {
-			const wrapper = new Vocal()
-			wrapper.cleanup()
-			expect(() => wrapper.removeEventListener(Vocal.eventTypes.START)).not.toThrow()
+		it('does nothing once cleaned up', () => {
+			const { vocal } = setup()
+			vocal.cleanup()
+			expect(() => vocal.off(eventTypes.START)).not.toThrow()
 		})
 
 		it('throws on invalid event types', () => {
-			const wrapper = new Vocal()
-			expect(() => wrapper.removeEventListener('invalid-type')).toThrow('Unknown event type "invalid-type"')
+			const { vocal } = setup()
+			expect(() => vocal.off('invalid-type')).toThrow('Unknown event type "invalid-type"')
 		})
 
 		it('does nothing when callback was never registered', () => {
-			const wrapper = new Vocal()
-			wrapper.addEventListener(Vocal.eventTypes.START, vi.fn())
-			expect(() => wrapper.removeEventListener(Vocal.eventTypes.START, vi.fn())).not.toThrow()
+			const { vocal } = setup()
+			vocal.on(eventTypes.START, vi.fn())
+			expect(() => vocal.off(eventTypes.START, vi.fn())).not.toThrow()
 		})
 
 		it('cleans up the listener entry when last callback is removed by reference', () => {
 			const onStart = vi.fn()
-			const wrapper = new Vocal()
-			wrapper.addEventListener(Vocal.eventTypes.START, onStart)
-			wrapper.removeEventListener(Vocal.eventTypes.START, onStart)
-			mockInstance(wrapper).start()
+			const { vocal, instance } = setup()
+			vocal.on(eventTypes.START, onStart)
+			vocal.off(eventTypes.START, onStart)
+			instance.start()
 			expect(onStart).not.toHaveBeenCalled()
 		})
 	})
@@ -475,9 +450,8 @@ describe('Vocal', () => {
 
 		it('restarts the engine after silence end when continuous is true', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal({ continuous: true })
-			await wrapper.start()
-			const instance = mockInstance(wrapper)
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
 			const initialStartCalls = (instance.start as MockFn).mock.calls.length
 
 			fireEnd(instance)
@@ -488,9 +462,8 @@ describe('Vocal', () => {
 
 		it('does not restart when continuous is false', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal({ continuous: false })
-			await wrapper.start()
-			const instance = mockInstance(wrapper)
+			const { vocal, instance } = setup({ continuous: false })
+			await vocal.start()
 			const initialStartCalls = (instance.start as MockFn).mock.calls.length
 
 			fireEnd(instance)
@@ -501,10 +474,9 @@ describe('Vocal', () => {
 
 		it('does not restart after explicit stop()', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal({ continuous: true })
-			await wrapper.start()
-			const instance = mockInstance(wrapper)
-			wrapper.stop()
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
+			vocal.stop()
 			const startCallsAfterStop = (instance.start as MockFn).mock.calls.length
 
 			await vi.advanceTimersByTimeAsync(1000)
@@ -514,10 +486,9 @@ describe('Vocal', () => {
 
 		it('does not restart after explicit abort()', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal({ continuous: true })
-			await wrapper.start()
-			const instance = mockInstance(wrapper)
-			wrapper.abort()
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
+			vocal.abort()
 			const startCallsAfterAbort = (instance.start as MockFn).mock.calls.length
 
 			await vi.advanceTimersByTimeAsync(1000)
@@ -527,9 +498,8 @@ describe('Vocal', () => {
 
 		it('throttles restart to at least 1000ms after last start', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal({ continuous: true })
-			await wrapper.start()
-			const instance = mockInstance(wrapper)
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
 			const initialStartCalls = (instance.start as MockFn).mock.calls.length
 
 			fireEnd(instance)
@@ -542,9 +512,8 @@ describe('Vocal', () => {
 
 		it('restarts immediately when more than 1000ms have elapsed since last start', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal({ continuous: true })
-			await wrapper.start()
-			const instance = mockInstance(wrapper)
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
 			const initialStartCalls = (instance.start as MockFn).mock.calls.length
 
 			await vi.advanceTimersByTimeAsync(1000 + 500)
@@ -556,13 +525,12 @@ describe('Vocal', () => {
 
 		it('cancels the scheduled restart when stop() is called during the throttle window', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal({ continuous: true })
-			await wrapper.start()
-			const instance = mockInstance(wrapper)
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
 			const initialStartCalls = (instance.start as MockFn).mock.calls.length
 
 			fireEnd(instance)
-			wrapper.stop()
+			vocal.stop()
 			await vi.advanceTimersByTimeAsync(1000)
 
 			expect((instance.start as MockFn).mock.calls.length).toBe(initialStartCalls)
@@ -570,13 +538,12 @@ describe('Vocal', () => {
 
 		it('cancels the scheduled restart when abort() is called during the throttle window', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal({ continuous: true })
-			await wrapper.start()
-			const instance = mockInstance(wrapper)
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
 			const initialStartCalls = (instance.start as MockFn).mock.calls.length
 
 			fireEnd(instance)
-			wrapper.abort()
+			vocal.abort()
 			await vi.advanceTimersByTimeAsync(1000)
 
 			expect((instance.start as MockFn).mock.calls.length).toBe(initialStartCalls)
@@ -584,9 +551,8 @@ describe('Vocal', () => {
 
 		it('disables auto-restart on not-allowed error', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal({ continuous: true })
-			await wrapper.start()
-			const instance = mockInstance(wrapper)
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
 			const initialStartCalls = (instance.start as MockFn).mock.calls.length
 
 			fireError(instance, 'not-allowed')
@@ -594,14 +560,13 @@ describe('Vocal', () => {
 			await vi.advanceTimersByTimeAsync(1000)
 
 			expect((instance.start as MockFn).mock.calls.length).toBe(initialStartCalls)
-			expect(wrapper.isRecording).toBe(false)
+			expect(vocal.isRecording).toBe(false)
 		})
 
 		it.each(['service-not-allowed', 'audio-capture'])('disables auto-restart on %s error', async (errorType) => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal({ continuous: true })
-			await wrapper.start()
-			const instance = mockInstance(wrapper)
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
 			const initialStartCalls = (instance.start as MockFn).mock.calls.length
 
 			fireError(instance, errorType)
@@ -613,9 +578,8 @@ describe('Vocal', () => {
 
 		it.each(['no-speech', 'network'])('keeps auto-restart active on transient %s error', async (errorType) => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal({ continuous: true })
-			await wrapper.start()
-			const instance = mockInstance(wrapper)
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
 			const initialStartCalls = (instance.start as MockFn).mock.calls.length
 
 			fireError(instance, errorType)
@@ -627,12 +591,12 @@ describe('Vocal', () => {
 
 		it('does not propagate intermediate end events to user listeners', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal({ continuous: true })
-			await wrapper.start()
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
 			const onEnd = vi.fn()
-			wrapper.addEventListener(Vocal.eventTypes.END, onEnd)
+			vocal.on(eventTypes.END, onEnd)
 
-			fireEnd(mockInstance(wrapper))
+			fireEnd(instance)
 			await vi.advanceTimersByTimeAsync(1000)
 
 			expect(onEnd).not.toHaveBeenCalled()
@@ -640,12 +604,12 @@ describe('Vocal', () => {
 
 		it('does not propagate the restart start event to user listeners', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal({ continuous: true })
-			await wrapper.start()
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
 			const onStart = vi.fn()
-			wrapper.addEventListener(Vocal.eventTypes.START, onStart)
+			vocal.on(eventTypes.START, onStart)
 
-			fireEnd(mockInstance(wrapper))
+			fireEnd(instance)
 			await vi.advanceTimersByTimeAsync(1000)
 
 			expect(onStart).not.toHaveBeenCalled()
@@ -653,37 +617,36 @@ describe('Vocal', () => {
 
 		it('still propagates end on explicit stop in continuous mode', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal({ continuous: true })
-			await wrapper.start()
+			const { vocal } = setup({ continuous: true })
+			await vocal.start()
 			const onEnd = vi.fn()
-			wrapper.addEventListener(Vocal.eventTypes.END, onEnd)
+			vocal.on(eventTypes.END, onEnd)
 
-			wrapper.stop()
+			vocal.stop()
 
 			expect(onEnd).toHaveBeenCalledTimes(1)
 		})
 
 		it('keeps isRecording true during the restart window', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal({ continuous: true })
-			await wrapper.start()
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
 
-			fireEnd(mockInstance(wrapper))
-			expect(wrapper.isRecording).toBe(true)
+			fireEnd(instance)
+			expect(vocal.isRecording).toBe(true)
 
 			await vi.advanceTimersByTimeAsync(1000)
-			expect(wrapper.isRecording).toBe(true)
+			expect(vocal.isRecording).toBe(true)
 		})
 
 		it('cancels the scheduled restart on cleanup()', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal({ continuous: true })
-			await wrapper.start()
-			const instance = mockInstance(wrapper)
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
 			const initialStartCalls = (instance.start as MockFn).mock.calls.length
 
 			fireEnd(instance)
-			wrapper.cleanup()
+			vocal.cleanup()
 			await vi.advanceTimersByTimeAsync(1000)
 
 			expect((instance.start as MockFn).mock.calls.length).toBe(initialStartCalls)
@@ -691,9 +654,8 @@ describe('Vocal', () => {
 
 		it('resets isRecording when the engine throws on restart', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal({ continuous: true })
-			await wrapper.start()
-			const instance = mockInstance(wrapper)
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
 
 			fireEnd(instance)
 			;(instance.start as unknown as { mockImplementationOnce: (fn: () => void) => void }).mockImplementationOnce(
@@ -704,25 +666,24 @@ describe('Vocal', () => {
 
 			await vi.advanceTimersByTimeAsync(1000)
 
-			expect(wrapper.isRecording).toBe(false)
+			expect(vocal.isRecording).toBe(false)
 		})
 	})
 
 	describe('aggregated result on stop()', () => {
 		it('emits a synthetic result event with the joined final transcripts', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal({ continuous: true })
-			await wrapper.start()
-			const instance = mockInstance(wrapper)
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
 
 			const onResult = vi.fn()
-			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
+			vocal.on(eventTypes.RESULT, onResult)
 
 			instance.say('hello')
 			instance.say('world')
 			onResult.mockClear()
 
-			wrapper.stop()
+			vocal.stop()
 
 			expect(onResult).toHaveBeenCalledTimes(1)
 			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'hello world', ['hello world'])
@@ -730,31 +691,30 @@ describe('Vocal', () => {
 
 		it('does not emit when no final result was received', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal()
-			await wrapper.start()
+			const { vocal } = setup()
+			await vocal.start()
 
 			const onResult = vi.fn()
-			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
+			vocal.on(eventTypes.RESULT, onResult)
 
-			wrapper.stop()
+			vocal.stop()
 
 			expect(onResult).not.toHaveBeenCalled()
 		})
 
 		it('ignores non-final (interim) results', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal({ continuous: true })
-			await wrapper.start()
-			const instance = mockInstance(wrapper)
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
 
 			const onResult = vi.fn()
-			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
+			vocal.on(eventTypes.RESULT, onResult)
 
 			instance.say('partial', undefined, { isFinal: false })
 			instance.say('final', undefined, { isFinal: true })
 			onResult.mockClear()
 
-			wrapper.stop()
+			vocal.stop()
 
 			expect(onResult).toHaveBeenCalledTimes(1)
 			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'final', ['final'])
@@ -762,35 +722,33 @@ describe('Vocal', () => {
 
 		it('does not emit on abort() and clears the buffer', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal({ continuous: true })
-			await wrapper.start()
-			const instance = mockInstance(wrapper)
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
 
 			instance.say('hello')
 
 			const onResult = vi.fn()
-			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
+			vocal.on(eventTypes.RESULT, onResult)
 
-			wrapper.abort()
+			vocal.abort()
 
 			expect(onResult).not.toHaveBeenCalled()
 		})
 
 		it('resets the buffer on subsequent start() so each session aggregates independently', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValue(mockStream)
-			const wrapper = new Vocal({ continuous: true })
-			await wrapper.start()
-			const instance = mockInstance(wrapper)
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
 
 			instance.say('first')
-			wrapper.stop()
+			vocal.stop()
 
 			const onResult = vi.fn()
-			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
-			await wrapper.start()
+			vocal.on(eventTypes.RESULT, onResult)
+			await vocal.start()
 
 			instance.say('second')
-			wrapper.stop()
+			vocal.stop()
 
 			expect(onResult).toHaveBeenLastCalledWith(expect.any(Event), 'second', ['second'])
 		})
@@ -799,9 +757,8 @@ describe('Vocal', () => {
 			vi.useFakeTimers()
 			try {
 				vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-				const wrapper = new Vocal({ continuous: true })
-				await wrapper.start()
-				const instance = mockInstance(wrapper)
+				const { vocal, instance } = setup({ continuous: true })
+				await vocal.start()
 
 				instance.say('hello')
 				;(instance.addEventListener.mock.calls as [string, EventListener][])
@@ -812,8 +769,8 @@ describe('Vocal', () => {
 				instance.say('again')
 
 				const onResult = vi.fn()
-				wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
-				wrapper.stop()
+				vocal.on(eventTypes.RESULT, onResult)
+				vocal.stop()
 
 				expect(onResult).toHaveBeenCalledTimes(1)
 				expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'hello again', ['hello again'])
@@ -824,9 +781,8 @@ describe('Vocal', () => {
 
 		it('falls back to the first alternative when confidence is missing', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal({ continuous: true })
-			await wrapper.start()
-			const instance = mockInstance(wrapper)
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
 
 			instance.say('hello', [
 				{ transcript: 'hello' } as unknown as { transcript: string; confidence: number },
@@ -834,17 +790,16 @@ describe('Vocal', () => {
 			])
 
 			const onResult = vi.fn()
-			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
-			wrapper.stop()
+			vocal.on(eventTypes.RESULT, onResult)
+			vocal.stop()
 
 			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'hello', ['hello'])
 		})
 
 		it('picks the highest-confidence alternative when aggregating', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const wrapper = new Vocal({ continuous: true })
-			await wrapper.start()
-			const instance = mockInstance(wrapper)
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
 
 			instance.say('helo', [
 				{ transcript: 'hello', confidence: 0.3 },
@@ -852,49 +807,35 @@ describe('Vocal', () => {
 			])
 
 			const onResult = vi.fn()
-			wrapper.addEventListener(Vocal.eventTypes.RESULT, onResult)
-			wrapper.stop()
+			vocal.on(eventTypes.RESULT, onResult)
+			vocal.stop()
 
 			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'helo', ['helo'])
 		})
 	})
 
 	describe('cleanup', () => {
-		let wrapper: Vocal
-		let instance: MockInstance
-
-		beforeEach(() => {
-			wrapper = new Vocal()
-			instance = mockInstance(wrapper)
-		})
-
 		it('calls stop on the instance', () => {
-			wrapper.cleanup()
+			const { vocal, instance } = setup()
+			vocal.cleanup()
 			expect(instance.stop).toHaveBeenCalled()
 		})
 
 		it('removes all registered listeners', () => {
-			wrapper.addEventListener(Vocal.eventTypes.START, vi.fn())
-			wrapper.addEventListener(Vocal.eventTypes.END, vi.fn())
-			wrapper.cleanup()
+			const { vocal, instance } = setup()
+			vocal.on(eventTypes.START, vi.fn())
+			vocal.on(eventTypes.END, vi.fn())
+			vocal.cleanup()
 			expect(instance.removeEventListener).toHaveBeenCalledTimes(6)
 		})
 
 		it('removes the internal end, start, error and result listeners on cleanup', () => {
-			wrapper.cleanup()
+			const { vocal, instance } = setup()
+			vocal.cleanup()
 			expect(instance.removeEventListener).toHaveBeenCalledWith('end', expect.any(Function))
 			expect(instance.removeEventListener).toHaveBeenCalledWith('start', expect.any(Function))
 			expect(instance.removeEventListener).toHaveBeenCalledWith('error', expect.any(Function))
 			expect(instance.removeEventListener).toHaveBeenCalledWith('result', expect.any(Function))
-		})
-
-		it('nulls the instance', () => {
-			wrapper.cleanup()
-			expect(mockInstance(wrapper)).toBeNull()
-		})
-
-		it('returns this for chaining', () => {
-			expect(wrapper.cleanup()).toBe(wrapper)
 		})
 	})
 })

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -228,6 +228,18 @@ describe('Vocal', () => {
 			await vocal.start()
 			expect(spy).toHaveBeenCalledWith('microphone', { audio: true }, { signal: undefined })
 		})
+
+		it('does not start recognition when signal aborts after the stream resolves', async () => {
+			const controller = new AbortController()
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockImplementationOnce(async () => {
+				controller.abort()
+				return mockStream
+			})
+			const { vocal, instance } = setup()
+			await vocal.start({ signal: controller.signal })
+			expect(instance.start).not.toHaveBeenCalled()
+			expect(vocal.isRecording).toBe(false)
+		})
 	})
 
 	describe('stop', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
-export { default as Vocal } from './Vocal'
+export { createVocal, isSupported, eventTypes } from './Vocal'
 export type {
 	VocalOptions,
+	VocalInstance,
 	EventType,
 	ResultEventHandler,
 	ErrorEventHandler,


### PR DESCRIPTION
## Summary

Replaces the `Vocal` class with a `createVocal()` factory and exposes `isSupported`, `eventTypes` and the related types as top-level named exports. State is held in closures — no more `this`, no more private fields, no more `new`. Behaviour (auto-restart, aggregation, listener semantics) is preserved 1:1; only the call sites change.

## Changes

- `src/Vocal.ts` — rewritten as a factory function with module-level helpers
- `src/index.ts` — new public surface: `createVocal`, `isSupported`, `eventTypes`, types
- `src/__tests__/Vocal.test.ts` — 74 tests migrated, 100% coverage maintained
- `demo/main.ts` — switched to the new API
- `README.md` — rewritten with the new examples and a migration snippet

## ⚠️ Breaking changes

The entire public surface changes:

- `new Vocal(options)` → `createVocal(options)`
- `Vocal.isSupported` (static getter) → `isSupported()` (function, call it)
- `Vocal.eventTypes` (static) → `eventTypes` (named export)
- `vocal.addEventListener(type, cb)` → `vocal.on(type, cb)`
- `vocal.removeEventListener(type, cb?)` → `vocal.off(type, cb?)`
- Side-effect methods (`stop`, `abort`, `on`, `off`, `cleanup`) return `void` — chaining is no longer supported
- The `Vocal` class is no longer exported; the `VocalInstance` interface describes the object returned by `createVocal()`

Migration:

```js
// Before
import { Vocal } from '@untemps/vocal'
if (!Vocal.isSupported) throw new Error()
const vocal = new Vocal({ lang: 'fr-FR' })
vocal.addEventListener('result', cb)

// After
import { createVocal, isSupported } from '@untemps/vocal'
if (!isSupported()) throw new Error()
const vocal = createVocal({ lang: 'fr-FR' })
vocal.on('result', cb)
```

## Test plan

- [x] `yarn test:ci` — 74 tests pass, 100% coverage
- [x] `yarn lint && yarn typecheck && yarn build` — all green (bundle shrinks from ~5.9 kB to ~3.5 kB CJS thanks to tree-shaking-friendly named exports)
- [ ] Manual: `yarn dev`, exercise the demo and confirm a basic start/say/stop cycle still works in the browser

Closes #86