### PR TITLE
chore: Ignore CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules/
 
 # Misc
 .DS_STORE
+CLAUDE.md
 
 # NPM
 npm-debug.log*


### PR DESCRIPTION
## Summary

Ajoute `CLAUDE.md` au `.gitignore`.

`CLAUDE.md` est un fichier de guidance local pour Claude Code. Son contenu varie entre les machines des contributeurs (wrappers d'outils, alias shell, chemins absolus, sections RTK locales, etc.). Le versionner provoque du churn inutile et des conflits ; l'ignorer plutôt.

## Test plan

- [x] `git status` propre malgré la présence d'un `CLAUDE.md` local.
- [x] Aucune modification de code applicatif — fichier de configuration uniquement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)