### PR TITLE
docs(contributing): Reference Conventional Commits with sentence-case subject

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Please follow those simple steps:
 - Create a feature branch  
 Preferred name convention: [feature type]/[imperative verb]-[description of the feature] > `feat/add-foo-support`
 - Develop the feature AND write the tests (or write the tests AND develop the feature)
-- Commit your changes using Angular Git Commit Guidelines
+- Commit your changes using [Conventional Commits](https://www.conventionalcommits.org/) with **sentence-case** subjects (e.g. `feat(core): Add foo support`, not `feat: add foo`). The repo's [`commitlint.config.js`](./commitlint.config.js) is the source of truth and the `commit-msg` Husky hook rejects non-conforming messages
 - Submit a Pull Request
 
 Thanks! :heart: :heart: :heart:


### PR DESCRIPTION
Closes #95

## Summary

`CONTRIBUTING.md` referred contributors to the "Angular Git Commit Guidelines" (lowercase subject), but the repo enforces Conventional Commits with a sentence-case subject via `commitlint.config.js` and the Husky `commit-msg` hook. External contributors who followed the doc verbatim saw their commit rejected with an opaque error.

This PR replaces the bullet with an explicit pointer to Conventional Commits, spells out the sentence-case requirement, and links to `commitlint.config.js` as the source of truth.

## Changes

- `CONTRIBUTING.md` — rewrite the commit-style bullet to match the actual lint rules.

## Test plan

- [x] `yarn test:ci` — 80 tests pass, 100% coverage.
- [x] `yarn lint`.
- [x] `yarn typecheck`.
- [x] Markdown-only change, no runtime impact.