### PR TITLE
docs(readme): Note continuous-mode result deferral in the events table

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Please refer to [this section](https://developer.mozilla.org/en-US/docs/Web/API/
 | end         | Fired when the recognition service has disconnected                                       |
 | error       | Fired when a recognition error occurs                                                     |
 | nomatch     | Fired when the recognition service returns a final result with no significant recognition |
-| result      | Fired when the recognition service returns a result — callback receives `(event, bestAlternative: string, alternatives: string[])` where `bestAlternative` is the alternative with the highest confidence |
+| result      | Fired when the recognition service returns a result — callback receives `(event, bestAlternative: string, alternatives: string[])` where `bestAlternative` is the alternative with the highest confidence. **In `continuous: true` mode, intermediate final results are deferred until explicit `stop()` (see [Aggregated result on stop](#aggregated-result-on-stop)).** |
 | soundend    | Fired when any sound — recognisable or not — has stopped being detected                   |
 | soundstart  | Fired when any sound — recognisable or not — has been detected                            |
 | speechend   | Fired when speech recognized by the recognition service has stopped being detected        |


### PR DESCRIPTION
Closes #96

## Summary

A consumer scanning only the events table did not learn that in `continuous: true` mode the `result` event is deferred until explicit `stop()`. The behaviour is fully documented in the "Aggregated result on stop" subsection, but the bare events table was misleading on its own.

This PR adds an inline note in the `result` row pointing to that subsection.

## Changes

- `README.md` — extend the `result` row in the events table with a note about continuous-mode deferral and a link to the existing subsection.

## Test plan

- [x] `yarn test:ci` — 80 tests pass, 100% coverage.
- [x] `yarn lint`.
- [x] `yarn typecheck`.
- [x] Markdown-only change, no runtime impact.