### PR TITLE
docs(readme): Add npm and pnpm install snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,14 @@ Functional wrapper around the SpeechRecognition Web API
 ## Installation
 
 ```bash
+# yarn
 yarn add @untemps/vocal
+
+# npm
+npm install @untemps/vocal
+
+# pnpm
+pnpm add @untemps/vocal
 ```
 
 ## Basic Usage


### PR DESCRIPTION
Closes #97

## Summary

The Installation section showed only `yarn add @untemps/vocal`. Users on npm or pnpm had to translate mentally. List the three main package managers in a single bash block so the equivalent command is one glance away.

## Changes

- `README.md` — extend the Installation snippet with `npm install` and `pnpm add` variants alongside the existing `yarn add`.

## Test plan

- [x] `yarn test:ci` — 80 tests pass, 100% coverage.
- [x] `yarn lint`.
- [x] `yarn typecheck`.
- [x] Markdown-only change, no runtime impact.