### PR TITLE
chore(build): Declare sideEffects false for tree-shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 	"main": "dist/index.cjs",
 	"module": "dist/index.es.js",
 	"types": "dist/index.d.ts",
+	"sideEffects": false,
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",


### PR DESCRIPTION
Closes #98

## Summary

The library has no top-level side effects: `createVocal`, `isSupported` and `eventTypes` are lazy/pure, and the resolve* helpers only run when invoked. The `declare global` block in `Vocal.ts` is TS-only and produces no runtime emit.

Declaring `"sideEffects": false` lets bundlers (Webpack, Rollup, esbuild, Vite, etc.) tree-shake unused exports from consumer bundles — a consumer importing only `isSupported` no longer drags in `createVocal` and its dependency on `@untemps/user-permissions-utils`.

## Changes

- `package.json` — add `"sideEffects": false`.

## Test plan

- [x] `yarn test:ci` — 80 tests pass, 100% coverage.
- [x] `yarn lint`.
- [x] `yarn typecheck`.
- [x] `yarn build` — both ESM (4.57 kB) and CJS (3.60 kB) bundles emit successfully.
- [x] `npm pack --dry-run` — the field is in the published `package.json`.