### PR TITLE
test(core): Lock in suppress-and-accumulate contract in a single test

### DIFF
--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -683,7 +683,7 @@ describe('Vocal', () => {
 	})
 
 	describe('aggregated result on stop()', () => {
-		it('does not propagate intermediate final results to user listeners in continuous mode', async () => {
+		it('does not propagate intermediate final results but still accumulates them in continuous mode', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
 			const { vocal, instance } = setup({ continuous: true })
 			await vocal.start()
@@ -695,6 +695,11 @@ describe('Vocal', () => {
 			instance.say('world')
 
 			expect(onResult).not.toHaveBeenCalled()
+
+			vocal.stop()
+
+			expect(onResult).toHaveBeenCalledTimes(1)
+			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'hello world', ['hello world'])
 		})
 
 		it('still propagates interim results to user listeners in continuous mode', async () => {


### PR DESCRIPTION
Closes #99

## Summary

The existing test only asserted that intermediate finals are not propagated to user listeners; it did not verify the other half of the contract — that the suppressed transcripts are still accumulated in `finalTranscripts`. A regression that broke both suppression and accumulation simultaneously (e.g. moving the suppression check above the internal `onResult` accumulator) would have passed.

This PR extends the test to call `vocal.stop()` and assert that the aggregated event delivers the joined transcripts. The test is renamed to reflect both halves of the invariant.

## Changes

- `src/__tests__/Vocal.test.ts` — extend the existing `does not propagate intermediate final results...` test with `vocal.stop()` + assertion on the aggregated emission; rename to `does not propagate intermediate final results but still accumulates them in continuous mode`.

## Test plan

- [x] `yarn test:ci` — 80 tests pass, 100% coverage on all four metrics.
- [x] `yarn lint`.
- [x] `yarn typecheck`.
- [x] Test-only change, no runtime impact.