### PR TITLE
test(core): Cover continuous + interimResults with mixed interim/final stream

### DIFF
--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -716,6 +716,29 @@ describe('Vocal', () => {
 			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'partial', ['partial'])
 		})
 
+		it('forwards interims and aggregates finals in continuous + interimResults mode', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+			const { vocal, instance } = setup({ continuous: true, interimResults: true })
+			await vocal.start()
+
+			const onResult = vi.fn()
+			vocal.on(eventTypes.RESULT, onResult)
+
+			instance.say('hel', undefined, { isFinal: false })
+			instance.say('hello', undefined, { isFinal: false })
+			instance.say('hello', undefined, { isFinal: true })
+
+			expect(onResult).toHaveBeenCalledTimes(2)
+			expect(onResult.mock.calls[0]).toEqual([expect.any(Event), 'hel', ['hel']])
+			expect(onResult.mock.calls[1]).toEqual([expect.any(Event), 'hello', ['hello']])
+
+			onResult.mockClear()
+			vocal.stop()
+
+			expect(onResult).toHaveBeenCalledTimes(1)
+			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'hello', ['hello'])
+		})
+
 		it('propagates final results to user listeners in non-continuous mode', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
 			const { vocal, instance } = setup({ continuous: false })


### PR DESCRIPTION
Closes #100

## Summary

The existing interim test only fired a single `isFinal: false` event. The real-world transcription use case mixes interim and final events in the same session — for example a live-caption UI showing progressive partials and committing each utterance to history on `isFinal: true`. That hybrid path had no regression coverage.

This PR adds a focused test that exercises the full contract.

## Changes

- `src/__tests__/Vocal.test.ts` — new test `forwards interims and aggregates finals in continuous + interimResults mode` covering:
  - two `isFinal: false` events forwarded to the user callback in real time with their respective transcripts,
  - one `isFinal: true` event suppressed from the live callback,
  - `vocal.stop()` emitting a single aggregated result with the final transcript.

## Test plan

- [x] `yarn test:ci` — 81 tests pass (was 80), 100% coverage on all four metrics.
- [x] `yarn lint`.
- [x] `yarn typecheck`.
- [x] Test-only change, no runtime impact.