### PR TITLE
test(core): Remove dead mockClear calls and tighten interim assertions

### DIFF
--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -807,7 +807,6 @@ describe('Vocal', () => {
 
 			instance.say('hello')
 			instance.say('world')
-			onResult.mockClear()
 
 			vocal.stop()
 
@@ -838,12 +837,14 @@ describe('Vocal', () => {
 
 			instance.say('partial', undefined, { isFinal: false })
 			instance.say('final', undefined, { isFinal: true })
-			onResult.mockClear()
+
+			expect(onResult).toHaveBeenCalledTimes(1)
+			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'partial', ['partial'])
 
 			vocal.stop()
 
-			expect(onResult).toHaveBeenCalledTimes(1)
-			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'final', ['final'])
+			expect(onResult).toHaveBeenCalledTimes(2)
+			expect(onResult).toHaveBeenLastCalledWith(expect.any(Event), 'final', ['final'])
 		})
 
 		it('does not emit on abort() and clears the buffer', async () => {


### PR DESCRIPTION
Closes #101

## Summary

Two existing continuous-mode tests called `onResult.mockClear()` between `say()` and `stop()`. With the suppress-finals behaviour from #89 in place, the clear became dead code (or obscured the real assertion) and made the test intent hard to read.

This PR removes the dead clear in one case and restructures the other to make both halves of the contract (interim forwarded live + final aggregated on stop) visible in the test body.

## Changes

- `src/__tests__/Vocal.test.ts`:
  - `emits a synthetic result event with the joined final transcripts` — both `say()` calls are continuous-mode finals, fully suppressed; the `mockClear()` had nothing to clear. Dropped.
  - `ignores non-final (interim) results` — the interim `say()` *does* reach the callback (only finals are suppressed in continuous mode), so the `mockClear()` was clearing a real call. Replaced with an explicit `expect(onResult).toHaveBeenCalledTimes(1)` + `toHaveBeenCalledWith('partial', ...)` before `stop()`, then a tighter `toHaveBeenLastCalledWith('final', ...)` after.

## Test plan

- [x] `yarn test:ci` — 81 tests pass, 100% coverage on all four metrics.
- [x] `yarn lint`.
- [x] `yarn typecheck`.
- [x] Test-only change, no runtime impact.