### PR TITLE
chore(demo): Expose dev server on LAN with host true

### DIFF
--- a/demo/vite.config.js
+++ b/demo/vite.config.js
@@ -3,6 +3,7 @@ import { defineConfig } from 'vite'
 export default defineConfig({
 	server: {
 		port: 3000,
+		host: true,
 		open: true,
 	},
 })


### PR DESCRIPTION
Closes #102

## Summary

`yarn dev` bound to localhost only, so testing the demo from a phone on the same Wi-Fi required either editing the config or remembering to pass `--host` on the CLI. This PR enables `host: true` so Vite listens on every network interface and prints the LAN URL at startup. No security impact — the demo is never started in CI.

## Changes

- `demo/vite.config.js` — add `host: true` inside the `server` block.

## Test plan

- [x] `yarn test:ci` — 81 tests pass, 100% coverage.
- [x] `yarn lint`.
- [x] `yarn typecheck`.
- [x] `yarn dev` now prints both `Local:` and `Network:` URLs at startup (verified locally with `http://192.168.1.150:3001/`).