### PR TITLE
fix(core): Re-check instance after getUserMediaStream awaits in start()

### DIFF
--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -265,6 +265,8 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		try {
 			const stream = (await getUserMediaStream('microphone', { audio: true }, { signal })) as MediaStream | null
 			if (signal?.aborted) return
+			// Re-check after the await: cleanup() may have nulled instance while we awaited.
+			if (!instance) return
 			if (!stream) {
 				throw new Error('Unable to retrieve the stream from media device')
 			}

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -240,6 +240,23 @@ describe('Vocal', () => {
 			expect(instance.start).not.toHaveBeenCalled()
 			expect(vocal.isRecording).toBe(false)
 		})
+
+		it('does not start recognition when cleanup runs while getUserMediaStream is pending', async () => {
+			let resolveStream!: (stream: MediaStream) => void
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockImplementationOnce(
+				() =>
+					new Promise<MediaStream>((resolve) => {
+						resolveStream = resolve
+					})
+			)
+			const { vocal, instance } = setup()
+			const startPromise = vocal.start()
+			vocal.cleanup()
+			resolveStream(mockStream)
+			await expect(startPromise).resolves.toBeUndefined()
+			expect(instance.start).not.toHaveBeenCalled()
+			expect(vocal.isRecording).toBe(false)
+		})
 	})
 
 	describe('stop', () => {


### PR DESCRIPTION
Closes #115

## Summary

If `vocal.cleanup()` ran while `getUserMediaStream()` was still pending, the closure-captured `instance` was nulled out and the subsequent `instance.start()` at the bottom of `start()` crashed with `TypeError`. This PR adds a defensive `if (!instance) return` right after the signal-aborted check, symmetric to the guard at function entry, so cleanup-during-start no-ops cleanly instead of crashing.

A regression test exercises the exact race: a never-resolved `getUserMediaStream` promise, `cleanup()` called while it is pending, then the promise resolves — `start()` must resolve without throwing and the underlying `SpeechRecognition.start()` must not be called.

## Changes

- `src/Vocal.ts` — add `if (!instance) return` after the signal-aborted check inside `start()`.
- `src/__tests__/Vocal.test.ts` — add `does not start recognition when cleanup runs while getUserMediaStream is pending` test.

## Test plan

- [x] `yarn test:ci` — 82 tests pass (was 81), 100% coverage on all four metrics.
- [x] `yarn lint`.
- [x] `yarn typecheck`.
- [x] `yarn build` — both ESM and CJS bundles emit successfully.