### PR TITLE
fix(core): Expose item() on synthetic aggregated result event

### DIFF
--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -128,6 +128,22 @@ const resolveSpeechGrammarList = (): typeof SpeechGrammarList | undefined =>
 const pickBestAlternative = <T extends { confidence?: number }>(alternatives: T[]): T =>
 	alternatives.reduce((a, b) => ((b.confidence ?? 0) > (a.confidence ?? 0) ? b : a))
 
+// Wrap a plain alternatives array so it satisfies SpeechRecognitionResult (isFinal + item()),
+// matching the lib.dom contract for consumers that call `event.results.item(i).item(j)`.
+const makeSyntheticResult = (alternatives: SpeechRecognitionAlternative[]): SpeechRecognitionResult => {
+	const result = alternatives.slice() as unknown as SpeechRecognitionResult & SpeechRecognitionAlternative[]
+	Object.defineProperty(result, 'isFinal', { value: true, enumerable: true })
+	Object.defineProperty(result, 'item', { value: (index: number) => alternatives[index] })
+	return result
+}
+
+// Wrap a plain results array so it satisfies SpeechRecognitionResultList (length + item()).
+const makeSyntheticResults = (results: SpeechRecognitionResult[]): SpeechRecognitionResultList => {
+	const list = results.slice() as unknown as SpeechRecognitionResultList & SpeechRecognitionResult[]
+	Object.defineProperty(list, 'item', { value: (index: number) => results[index] })
+	return list
+}
+
 const includesEventType = (eventType: string): boolean => Object.values(eventTypes).includes(eventType as EventType)
 
 const unknownEventTypeMessage = (eventType: string): string =>
@@ -197,10 +213,10 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		if (!listeners[eventTypes.RESULT]?.length) return
 
 		const aggregatedTranscripts = transcripts.join(' ').trim()
-		const result = Object.assign([{ transcript: aggregatedTranscripts, confidence: 1 }], { isFinal: true })
+		const result = makeSyntheticResult([{ transcript: aggregatedTranscripts, confidence: 1 }])
 		const event = Object.assign(new Event(eventTypes.RESULT), {
 			resultIndex: 0,
-			results: [result],
+			results: makeSyntheticResults([result]),
 		})
 
 		// Snapshot listeners to stay safe if a handler removes itself during dispatch.

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -130,17 +130,19 @@ const pickBestAlternative = <T extends { confidence?: number }>(alternatives: T[
 
 // Wrap a plain alternatives array so it satisfies SpeechRecognitionResult (isFinal + item()),
 // matching the lib.dom contract for consumers that call `event.results.item(i).item(j)`.
+// isFinal and item are non-enumerable to mirror how lib.dom exposes them and to keep
+// JSON.stringify output identical to the underlying alternatives array.
 const makeSyntheticResult = (alternatives: SpeechRecognitionAlternative[]): SpeechRecognitionResult => {
 	const result = alternatives.slice() as unknown as SpeechRecognitionResult & SpeechRecognitionAlternative[]
-	Object.defineProperty(result, 'isFinal', { value: true, enumerable: true })
-	Object.defineProperty(result, 'item', { value: (index: number) => alternatives[index] })
+	Object.defineProperty(result, 'isFinal', { value: true })
+	Object.defineProperty(result, 'item', { value: (index: number) => result[index] })
 	return result
 }
 
 // Wrap a plain results array so it satisfies SpeechRecognitionResultList (length + item()).
 const makeSyntheticResults = (results: SpeechRecognitionResult[]): SpeechRecognitionResultList => {
 	const list = results.slice() as unknown as SpeechRecognitionResultList & SpeechRecognitionResult[]
-	Object.defineProperty(list, 'item', { value: (index: number) => results[index] })
+	Object.defineProperty(list, 'item', { value: (index: number) => list[index] })
 	return list
 }
 

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -829,8 +829,10 @@ describe('Vocal', () => {
 			expect(onResult).toHaveBeenCalledTimes(1)
 			const event = onResult.mock.calls[0][0] as SpeechRecognitionEvent
 			expect(typeof event.results.item).toBe('function')
+			expect(event.results.length).toBe(1)
 			const firstResult = event.results.item(0)
 			expect(firstResult.isFinal).toBe(true)
+			expect(firstResult.length).toBe(1)
 			expect(typeof firstResult.item).toBe('function')
 			expect(firstResult.item(0).transcript).toBe('hello world')
 		})

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -814,6 +814,27 @@ describe('Vocal', () => {
 			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'hello world', ['hello world'])
 		})
 
+		it('exposes item() on the synthetic aggregated result for lib.dom compatibility', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
+
+			const onResult = vi.fn()
+			vocal.on(eventTypes.RESULT, onResult)
+
+			instance.say('hello')
+			instance.say('world')
+			vocal.stop()
+
+			expect(onResult).toHaveBeenCalledTimes(1)
+			const event = onResult.mock.calls[0][0] as SpeechRecognitionEvent
+			expect(typeof event.results.item).toBe('function')
+			const firstResult = event.results.item(0)
+			expect(firstResult.isFinal).toBe(true)
+			expect(typeof firstResult.item).toBe('function')
+			expect(firstResult.item(0).transcript).toBe('hello world')
+		})
+
 		it('emits a synthetic result event with the joined final transcripts', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
 			const { vocal, instance } = setup({ continuous: true })


### PR DESCRIPTION
Closes #116

## Summary

`emitAggregatedResult` built the inner `result` and outer `results` as plain `Object.assign`-augmented arrays. They supported `[index]` access but lacked the `.item(index)` method that lib.dom declares on `SpeechRecognitionResult` and `SpeechRecognitionResultList`. A consumer following the canonical Web Speech API contract (`event.results.item(0).item(0).transcript`) crashed with `TypeError` on the synthetic aggregated event, even though it worked on real browser events.

This PR wraps the synthetic structures with two small helpers (`makeSyntheticResult` / `makeSyntheticResults`) that define `.item()` as a non-enumerable property — so `JSON.stringify` of the event still serialises only the alternative fields, but typed consumers can call `.item()` the same way they would on a real event.

## Changes

- `src/Vocal.ts` — add `makeSyntheticResult` / `makeSyntheticResults` helpers next to `pickBestAlternative`; use them inside `emitAggregatedResult`.
- `src/__tests__/Vocal.test.ts` — add `exposes item() on the synthetic aggregated result for lib.dom compatibility` test verifying `event.results.item(0).item(0).transcript`.

## Test plan

- [x] `yarn test:ci` — 83 tests pass (was 82), 100% coverage on all four metrics.
- [x] `yarn lint`.
- [x] `yarn typecheck`.
- [x] `yarn build` — bundle sizes ESM 4.62 kB / CJS 3.79 kB (tiny increase from helper definitions).

## Compatibility

No breaking change. Consumers using `event.results[0][0]` continue to work; those calling `event.results.item(0).item(0)` are newly supported.