### PR TITLE
test(setup): Expose item() on mocked SpeechRecognition result and resultList

### DIFF
--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -304,6 +304,19 @@ describe('Vocal', () => {
 			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'hello world', ['hello world'])
 		})
 
+		it('exposes item() on mocked RESULT events for lib.dom-compliant consumers', () => {
+			const onResult = vi.fn()
+			const { vocal, instance } = setup()
+			vocal.on(eventTypes.RESULT, onResult)
+			instance.say('hello')
+			const event = onResult.mock.calls[0][0] as SpeechRecognitionEvent
+			expect(typeof event.results.item).toBe('function')
+			const firstResult = event.results.item(0)
+			expect(firstResult.isFinal).toBe(true)
+			expect(typeof firstResult.item).toBe('function')
+			expect(firstResult.item(0).transcript).toBe('hello')
+		})
+
 		it('passes all alternatives when multiple are available', () => {
 			const onResult = vi.fn()
 			const { vocal, instance } = setup()

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -108,16 +108,17 @@ global.SpeechRecognition = vi.fn(function () {
 			dispatch('speechstart')
 
 			const alts = alternatives ?? [sentence]
-			const result = Object.assign(
-				alts.map((t) => (typeof t === 'string' ? { transcript: t, confidence: 0 } : t)),
-				{ isFinal: options?.isFinal ?? true }
-			)
+			const result = alts.map((t) => (typeof t === 'string' ? { transcript: t, confidence: 0 } : t))
+			Object.defineProperty(result, 'isFinal', { value: options?.isFinal ?? true })
+			Object.defineProperty(result, 'item', { value: (index: number) => result[index] })
+			const results = [result]
+			Object.defineProperty(results, 'item', { value: (index: number) => results[index] })
 			const resultEvent = new Event('result') as Event & {
 				resultIndex: number
-				results: (typeof result)[]
+				results: typeof results
 			}
 			resultEvent.resultIndex = 0
-			resultEvent.results = [result]
+			resultEvent.results = results
 			if (sentence) {
 				dispatch('result', resultEvent)
 			} else {


### PR DESCRIPTION
Closes #118

## Summary

The `say()` mock built `result` events as plain arrays — supported `[index]` access but missing the `.item(index)` method that lib.dom declares on `SpeechRecognitionResult` and `SpeechRecognitionResultList`. Tests passed because the production code only used indexed access, but any future refactor adopting the canonical lib.dom accessor would have silently broken against the mock (or, worse, accidentally been excused by a mock-vs-real-API divergence).

This PR wraps both the inner `result` (alternatives) and the outer `results` arrays with `.item()` via `Object.defineProperty`, non-enumerable to mirror the `makeSyntheticResult` / `makeSyntheticResults` helpers in `Vocal.ts` so the mocked and synthetic shapes are now identical.

A regression guard test calls `event.results.item(0).item(0).transcript` on a mock-dispatched event so the mock shape stays aligned with lib.dom going forward.

## Changes

- `vitest.setup.ts` — extend the `say()` mock to define `.item()` on `result` and `results`.
- `src/__tests__/Vocal.test.ts` — add `exposes item() on mocked RESULT events for lib.dom-compliant consumers` test in the `on` describe block.

## Test plan

- [x] `yarn test:ci` — 84 tests pass (was 83), 100% coverage on all four metrics.
- [x] `yarn lint`.
- [x] `yarn typecheck`.
- [x] Test-only change, no runtime impact.