### PR TITLE
feat(core)!: Preserve real confidence and alternatives in aggregated result event

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,25 @@ The restart is disabled automatically when the recognition emits a fatal error (
 
 To compensate for results being split across silent restart cycles, Vocal accumulates every final result (`isFinal: true`) received during a session. On explicit `stop()`, a single `result` event carrying the joined transcripts is emitted alongside the `end` event — in `continuous: true` mode, this aggregated event is the only `result` your listener receives (intermediate finals are suppressed). Interim results and `abort()` are excluded — `abort()` discards the buffer without emitting.
 
-The aggregated event is a synthetic `Event` shaped to match `SpeechRecognitionEvent`: it carries `resultIndex` plus a `results` list whose entries support both index access (`results[0][0]`) and the lib.dom `.item()` accessor (`results.item(0).item(0)`). It is not a real `SpeechRecognitionEvent` instance, so `event instanceof SpeechRecognitionEvent` returns `false`. The most portable pattern is to read the joined transcript through the second argument of the listener — it works identically for real and synthetic events:
+The aggregated event is a synthetic `Event` shaped to match `SpeechRecognitionEvent`: it carries `resultIndex: 0` and a `results` list with **one entry per captured utterance**, each preserving the real alternatives and confidences the browser reported. Entries support both index access (`results[i][j]`) and the lib.dom `.item()` accessor (`results.item(i).item(j)`). The event is not a real `SpeechRecognitionEvent` instance, so `event instanceof SpeechRecognitionEvent` returns `false`.
+
+The simplest pattern is to read the joined transcript through the second argument of the listener — it returns the per-utterance best transcripts joined with spaces, and works identically for real and synthetic events:
 
 ```ts
 vocal.on('result', (event, bestAlternative) => {
-  console.log(bestAlternative) // works for both real and synthetic events
+  console.log(bestAlternative) // joined transcript across all captured utterances
+})
+```
+
+For per-utterance detail (confidence, alternative count, etc.), iterate over `event.results`:
+
+```ts
+vocal.on('result', (event) => {
+  for (let i = 0; i < event.results.length; i++) {
+    const result = event.results.item(i)
+    const best = result.item(0)
+    console.log(best.transcript, best.confidence)
+  }
 })
 ```
 

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -167,8 +167,7 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 	let lastStartedAt = 0
 	let restartTimeoutId: ReturnType<typeof setTimeout> | null = null
 	let isRestarting = false
-	let emittingAggregated = false
-	let finalTranscripts: string[] = []
+	let finalResults: SpeechRecognitionResult[] = []
 
 	const resolvedOptions: Required<VocalOptions> = {
 		...defaultOptions,
@@ -209,25 +208,28 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 	}
 
 	const emitAggregatedResult = (): void => {
-		const transcripts = finalTranscripts
-		finalTranscripts = []
-		if (transcripts.length === 0) return
+		const results = finalResults
+		finalResults = []
+		if (results.length === 0) return
 		if (!listeners[eventTypes.RESULT]?.length) return
 
-		const aggregatedTranscripts = transcripts.join(' ').trim()
-		const result = makeSyntheticResult([{ transcript: aggregatedTranscripts, confidence: 1 }])
+		const joinedTranscript = results
+			.map((result) => pickBestAlternative(Array.from(result)).transcript)
+			.join(' ')
+			.trim()
 		const event = Object.assign(new Event(eventTypes.RESULT), {
 			resultIndex: 0,
-			results: makeSyntheticResults([result]),
+			results: makeSyntheticResults(results),
 		})
 
-		// Snapshot listeners to stay safe if a handler removes itself during dispatch.
-		emittingAggregated = true
-		try {
-			;[...listeners[eventTypes.RESULT]].forEach(({ handler }) => handler(event))
-		} finally {
-			emittingAggregated = false
-		}
+		// Bypass the wrapper registered via on() — the synthetic event carries N real
+		// per-utterance results, so the aggregate-level (bestAlternative, alternatives)
+		// pair must be computed from the joined transcript instead of from a single
+		// result's alternatives. Snapshot the listener list to stay safe if a handler
+		// removes itself during dispatch.
+		;[...listeners[eventTypes.RESULT]].forEach(({ callback }) => {
+			callback(event, joinedTranscript, [joinedTranscript])
+		})
 	}
 
 	const onEnd = (event: Event): void => {
@@ -267,7 +269,9 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		const speechEvent = event as SpeechRecognitionEvent
 		const result = speechEvent.results?.[speechEvent.resultIndex]
 		if (!result?.isFinal) return
-		finalTranscripts.push(pickBestAlternative(Array.from(result)).transcript)
+		// Snapshot the result so we own its alternatives and the browser cannot mutate
+		// them between now and the aggregated dispatch on stop().
+		finalResults.push(makeSyntheticResult(Array.from(result)))
 	}
 
 	const internalListeners: Array<[EventType, EventListener]> = [
@@ -289,7 +293,7 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 				throw new Error('Unable to retrieve the stream from media device')
 			}
 			explicitStop = false
-			finalTranscripts = []
+			finalResults = []
 			instance.start()
 			isRecording = true
 			lastStartedAt = Date.now()
@@ -312,7 +316,7 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		explicitStop = true
 		clearRestartTimeout()
 		// Clear before instance.abort() so the resulting 'end' → onEnd → emitAggregatedResult is a no-op.
-		finalTranscripts = []
+		finalResults = []
 		instance.abort()
 		isRecording = false
 	}
@@ -337,7 +341,9 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 				return
 			}
 			const result = speechEvent.results[speechEvent.resultIndex]
-			if (resolvedOptions.continuous && !emittingAggregated && result.isFinal) {
+			// Suppress finals in continuous mode — they are accumulated and re-emitted
+			// in aggregated form by emitAggregatedResult (which bypasses this wrapper).
+			if (resolvedOptions.continuous && result.isFinal) {
 				return
 			}
 			const alternatives = Array.from(result)

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -827,7 +827,7 @@ describe('Vocal', () => {
 			expect(onResult).toHaveBeenCalledWith(expect.any(Event), 'hello world', ['hello world'])
 		})
 
-		it('exposes item() on the synthetic aggregated result for lib.dom compatibility', async () => {
+		it('exposes per-utterance results on the synthetic aggregated event via item()', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
 			const { vocal, instance } = setup({ continuous: true })
 			await vocal.start()
@@ -842,12 +842,54 @@ describe('Vocal', () => {
 			expect(onResult).toHaveBeenCalledTimes(1)
 			const event = onResult.mock.calls[0][0] as SpeechRecognitionEvent
 			expect(typeof event.results.item).toBe('function')
-			expect(event.results.length).toBe(1)
-			const firstResult = event.results.item(0)
-			expect(firstResult.isFinal).toBe(true)
-			expect(firstResult.length).toBe(1)
-			expect(typeof firstResult.item).toBe('function')
-			expect(firstResult.item(0).transcript).toBe('hello world')
+			expect(event.results.length).toBe(2)
+			expect(event.results.item(0).isFinal).toBe(true)
+			expect(event.results.item(0).item(0).transcript).toBe('hello')
+			expect(event.results.item(1).isFinal).toBe(true)
+			expect(event.results.item(1).item(0).transcript).toBe('world')
+		})
+
+		it('preserves real confidence per utterance in the aggregated event', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+			const { vocal, instance } = setup({ continuous: true })
+			await vocal.start()
+
+			const onResult = vi.fn()
+			vocal.on(eventTypes.RESULT, onResult)
+
+			instance.say('hello', [{ transcript: 'hello', confidence: 0.82 }])
+			instance.say('world', [{ transcript: 'world', confidence: 0.91 }])
+			vocal.stop()
+
+			const event = onResult.mock.calls[0][0] as SpeechRecognitionEvent
+			expect(event.results[0][0].confidence).toBe(0.82)
+			expect(event.results[1][0].confidence).toBe(0.91)
+		})
+
+		it('preserves all alternatives per utterance in the aggregated event', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+			const { vocal, instance } = setup({ continuous: true, maxAlternatives: 3 })
+			await vocal.start()
+
+			const onResult = vi.fn()
+			vocal.on(eventTypes.RESULT, onResult)
+
+			instance.say('hello', [
+				{ transcript: 'hello', confidence: 0.9 },
+				{ transcript: 'helo', confidence: 0.6 },
+				{ transcript: 'hell', confidence: 0.4 },
+			])
+			instance.say('world', [
+				{ transcript: 'world', confidence: 0.8 },
+				{ transcript: 'whirl', confidence: 0.5 },
+			])
+			vocal.stop()
+
+			const event = onResult.mock.calls[0][0] as SpeechRecognitionEvent
+			expect(event.results[0].length).toBe(3)
+			expect(Array.from(event.results[0]).map((a) => a.transcript)).toEqual(['hello', 'helo', 'hell'])
+			expect(event.results[1].length).toBe(2)
+			expect(Array.from(event.results[1]).map((a) => a.transcript)).toEqual(['world', 'whirl'])
 		})
 
 		it('emits a synthetic result event with the joined final transcripts', async () => {


### PR DESCRIPTION
Closes #119

## Summary

The aggregated `result` event flattened every captured utterance into a single fake `SpeechRecognitionResult` with `confidence: 1` and one alternative carrying the joined transcript. Consumers that requested `maxAlternatives: 3` still saw a single alternative, and confidence-based gating was impossible because the value was hardcoded.

This PR restructures the buffer from `string[]` to `SpeechRecognitionResult[]`: each `onResult` now snapshots the real result (alternatives + confidences) via `makeSyntheticResult(Array.from(result))`. `emitAggregatedResult` builds `event.results` with one entry per utterance, preserving the per-utterance shape. The listener callback still receives the joined transcript as `bestAlternative` and `[joinedTranscript]` as the third argument — these are derived by joining each result's best alternative on dispatch.

The synthetic dispatch invokes user `callback` functions directly, bypassing the DOM-style wrapper, so the 2nd/3rd args can be attached independently of the per-utterance shape on `event.results`. The previously needed `emittingAggregated` flag and its `try/finally` are removed.

## Changes

- `src/Vocal.ts` — buffer is now `finalResults: SpeechRecognitionResult[]`; `onResult` snapshots full results; `emitAggregatedResult` builds an `event.results` list of N entries and dispatches user callbacks directly with the joined transcript as 2nd/3rd args.
- `src/__tests__/Vocal.test.ts` — update the `.item()` test (results.length now 2, no longer 1); add `preserves real confidence per utterance` and `preserves all alternatives per utterance` tests.
- `README.md` — rewrite the **Aggregated result on stop** section to describe the new per-utterance shape; document both the `bestAlternative` (unchanged joined transcript) and the iteration pattern via `event.results.item(i).item(j)`.

## ⚠️ Breaking changes

- **`event.results`** : no longer contains a single fake result. It now contains **N entries** (one per captured final utterance), each with its real alternatives and confidences.
- **`event.results[0][0].transcript`** : previously returned the joined transcript (`'hello world'`). It now returns only the first utterance's best transcript (`'hello'`).
- **`event.results[0][0].confidence`** : previously hardcoded to `1`. It now reflects the real browser-provided confidence.
- **Migration** : read `bestAlternative` (the 2nd argument of the listener) for the joined transcript — its value is **unchanged**. To enumerate per-utterance detail, iterate `event.results`:

```ts
vocal.on('result', (event, bestAlternative) => {
  console.log(bestAlternative) // unchanged: joined transcript across all utterances
  for (let i = 0; i < event.results.length; i++) {
    const best = event.results.item(i).item(0)
    console.log(best.transcript, best.confidence)
  }
})
```

## Test plan

- [x] `yarn test:ci` — 86 tests pass (was 84), 100% coverage on all four metrics.
- [x] `yarn lint`.
- [x] `yarn typecheck`.
- [x] `yarn build` — ESM 4.74 kB / CJS 3.75 kB.