### PR TITLE
docs(readme): Add browser support matrix to Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,22 @@ Functional wrapper around the SpeechRecognition Web API
 
 ## Requirements
 
-- A modern browser exposing the `SpeechRecognition` Web API (Chrome, Edge, Safari ≥ 14.1). The library is browser-only — it cannot run on the server.
+- A modern browser exposing the `SpeechRecognition` Web API (see [browser support](#browser-support) below). The library is browser-only — it cannot run on the server.
 - **TypeScript ≥ 6.0** for full type resolution. The published declarations rely on `SpeechRecognitionEvent` and `SpeechRecognitionErrorEvent` shipped by `lib.dom` starting with TypeScript 6.0. If you target an older TypeScript release, install [`@types/dom-speech-recognition`](https://www.npmjs.com/package/@types/dom-speech-recognition) to provide the missing ambient declarations.
+
+### Browser support
+
+| Browser | Desktop  | Mobile (iOS) | Mobile (Android) |
+| ------- | -------- | ------------ | ---------------- |
+| Chrome  | ✅ 25+   | ✅ 121+      | ✅ 25+           |
+| Edge    | ✅ 79+   | ✅ 121+      | ✅ 79+           |
+| Safari  | ✅ 14.1+ | ✅ 14.5+     | —                |
+| Opera   | ✅ 27+   | ⚠️ partial   | ✅ 27+           |
+| Firefox | ❌       | ❌           | ❌               |
+
+Firefox does not implement the Web Speech `SpeechRecognition` API natively. `isSupported()` returns `false` there. Refer to [caniuse.com](https://caniuse.com/?search=SpeechRecognition) for the most up-to-date matrix.
+
+Vendor-prefixed globals (`webkitSpeechRecognition`, `mozSpeechRecognition`, `msSpeechRecognition`, and the matching `*SpeechGrammarList` constructors) are detected transparently — consumers do not need to handle them themselves.
 
 ## Installation
 


### PR DESCRIPTION
Closes #120

## Summary

The Requirements section said only "Chrome, Edge, Safari ≥ 14.1" without per-platform versions or explicit Firefox status. Firefox users installed the lib and discovered at runtime that `isSupported()` returned `false`; mobile users had no signal about Safari iOS or Chrome Android coverage.

This PR adds a Browser support subsection with a per-platform matrix (Desktop / Mobile iOS / Mobile Android) for Chrome, Edge, Safari, Opera, and Firefox, plus a short note about transparent vendor-prefix resolution and a link to caniuse for live tracking.

## Changes

- `README.md` — add `### Browser support` under `## Requirements` with a markdown table, a paragraph on Firefox status + caniuse link, and a note about the transparent `webkit*`/`moz*`/`ms*` resolution performed by Vocal internally.

## Test plan

- [x] `yarn test:ci` — 84 tests pass, 100% coverage.
- [x] `yarn lint`.
- [x] `yarn typecheck`.
- [x] Markdown-only change, no runtime impact.