### PR TITLE
feat: Optimal migration to @untemps/user-permissions-utils v2 (sync isSupported + microphone permission events)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pnpm add @untemps/vocal
 ```javascript
 import { createVocal, isSupported } from '@untemps/vocal'
 
-// Check whether SpeechRecognition, Permissions and MediaDevices interfaces are supported
+// Check whether the SpeechRecognition and MediaDevices interfaces are supported
 if (!isSupported()) {
   throw new Error('Vocal is not supported')
 }
@@ -137,6 +137,7 @@ Please refer to [this section](https://developer.mozilla.org/en-US/docs/Web/API/
 | speechend   | Fired when speech recognized by the recognition service has stopped being detected        |
 | speechstart | Fired when sound recognized by the recognition service as speech has been detected        |
 | start       | fired when the recognition service has begun listening to incoming audio                  |
+| permission  | **Library-synthetic** (not a native `SpeechRecognition` event). Fired with the current microphone permission state on `start()` and on every transition during the session (see [Microphone permission event](#microphone-permission-event)). |
 
 For convenience, `eventTypes` is exported as a constant map so consumers can reference type strings symbolically:
 
@@ -145,12 +146,25 @@ import { eventTypes } from '@untemps/vocal'
 vocal.on(eventTypes.RESULT, handler)
 ```
 
+### Microphone permission event
+
+Unlike every other event above, `permission` is **synthesised by Vocal** — the native `SpeechRecognition` instance never emits it. On `start()`, Vocal observes the microphone permission through the [Permissions API](https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API) and emits the current state immediately, then re-emits on every transition for the lifetime of the session (e.g. when the user grants or revokes access). The handler receives the state both as a second argument and on `event.state`:
+
+```ts
+vocal.on('permission', (event, state) => {
+  // state: 'granted' | 'denied' | 'prompt' (also available as event.state)
+  console.log('Microphone permission:', state)
+})
+```
+
+The observation is **best-effort**: it never displays a prompt itself (only `start()` does, through `getUserMediaStream`), and it stays silent on browsers where the Permissions API is unavailable or where `microphone` is not queryable (Firefox, Safari). The subscription is torn down automatically on `stop()`, `abort()`, `cleanup()`, or when the `AbortSignal` passed to `start()` aborts — no listener leaks.
+
 ## Top-level exports
 
 | Export        | Kind     | Description                                                                                                          |
 | ------------- | -------- | -------------------------------------------------------------------------------------------------------------------- |
 | `createVocal` | function | Factory that returns a `VocalInstance`. See [Methods](#methods).                                                     |
-| `isSupported` | function | Returns `true` if the current environment supports the SpeechRecognition Web API. Call it (it is **not** a getter).  |
+| `isSupported` | function | Returns `true` when both the `SpeechRecognition` Web API and `navigator.mediaDevices.getUserMedia` are available. The Permissions API is **not** required (it is best-effort). Call it (it is **not** a getter). |
 | `eventTypes`  | const    | Map of valid event type strings (e.g. `eventTypes.RESULT === 'result'`).                                             |
 
 ## Instance getter
@@ -163,15 +177,32 @@ vocal.on(eventTypes.RESULT, handler)
 
 ### `start({ signal? })`
 
-Starts recognition. Resolves once the engine is active. Rejects if microphone permission cannot be obtained.
+Starts recognition. Resolves once the engine is active. Acquires the microphone through `getUserMediaStream` and, in parallel, emits the [`permission` event](#microphone-permission-event) with the current state and on every transition.
+
+Rejects if the microphone stream cannot be acquired. The rejection is the **original `DOMException`** thrown by `getUserMedia`, so it can be discriminated by `name`:
+
+| `error.name`      | Meaning                                              |
+| ----------------- | ---------------------------------------------------- |
+| `NotAllowedError` | The user denied microphone permission                |
+| `NotFoundError`   | No matching input device was found                   |
+| _(others)_        | Any other `getUserMedia` `DOMException` is propagated as-is |
+
+Cancelling the in-flight request via the `signal` resolves (it does **not** reject) — the `AbortError` is swallowed.
 
 | Parameter | Type          | Default     | Description                                                                   |
 | --------- | ------------- | ----------- | ----------------------------------------------------------------------------- |
-| signal    | AbortSignal   | `undefined` | Cancels the in-flight microphone permission request when the signal is aborted |
+| signal    | AbortSignal   | `undefined` | Cancels the in-flight microphone request and tears down the permission watch when aborted |
 
 ```js
 const controller = new AbortController()
-vocal.start({ signal: controller.signal })
+
+try {
+  await vocal.start({ signal: controller.signal })
+} catch (error) {
+  if (error.name === 'NotAllowedError') {
+    // microphone permission denied
+  }
+}
 
 // Cancel the permission request at any later point
 controller.abort()
@@ -228,5 +259,14 @@ const vocal = createVocal({ lang: 'fr-FR' })
 vocal.on('result', cb)
 vocal.off('result', cb)
 ```
+
+## Migration to v3 (behaviour changes)
+
+v3 migrates the internal `@untemps/user-permissions-utils` dependency to v2. The public API surface is unchanged, but two observable behaviours differ:
+
+- **`start()` rejection** — on a failed acquisition, `start()` now rejects with the **original `getUserMedia` `DOMException`** (`NotAllowedError`, `NotFoundError`, …) instead of the generic `Error('Unable to retrieve the stream from media device')`. Discriminate on `error.name` (see [`start()`](#start-signal-)). Code that matched the old message string must be updated.
+- **`isSupported()` no longer requires the Permissions API** — it now returns `true` whenever `SpeechRecognition` and `navigator.mediaDevices.getUserMedia` are available. This **widens** support (e.g. older Safari builds without `navigator.permissions` where recognition actually works) and never narrows it.
+
+The new [`permission` event](#microphone-permission-event) is purely additive — existing listeners are unaffected.
 
 Side-effect methods (`stop`, `abort`, `on`, `off`, `cleanup`) now return `void` — method chaining is no longer supported. `Vocal.eventTypes` is now exported as the top-level `eventTypes` const.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ vocal.on('permission', (event, state) => {
 })
 ```
 
-The observation is **best-effort**: it never displays a prompt itself (only `start()` does, through `getUserMediaStream`), and it stays silent on browsers where the Permissions API is unavailable or where `microphone` is not queryable (Firefox, Safari). The subscription is torn down automatically on `stop()`, `abort()`, `cleanup()`, or when the `AbortSignal` passed to `start()` aborts — no listener leaks.
+The observation is **best-effort**: it never displays a prompt itself (only `start()` does, through `getUserMediaStream`), and it stays silent on browsers where the Permissions API is unavailable or where `microphone` is not queryable (Firefox, Safari). The subscription is torn down automatically when recognition ends, on `stop()`, `abort()`, `cleanup()`, or when the `AbortSignal` passed to `start()` aborts — no listener leaks. (In continuous mode it survives the transparent auto-restarts between utterances.)
 
 ## Top-level exports
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -97,6 +97,7 @@
 
 			.badge.yes { background: #1a3a2a; color: var(--success); }
 			.badge.no  { background: #3a1a1a; color: var(--danger); }
+			.badge.warn { background: #3a2e1a; color: var(--warn); }
 			.badge.recording { background: #2a1a3a; color: var(--accent); animation: pulse 1.2s ease-in-out infinite; }
 
 			@keyframes pulse { 0%,100%{ opacity:1; } 50%{ opacity:.5; } }
@@ -320,6 +321,10 @@
 						<div class="status-row">
 							<span>isRecording</span>
 							<span id="status-recording" class="badge no">false</span>
+						</div>
+						<div class="status-row">
+							<span>permission</span>
+							<span id="status-permission" class="badge warn">unknown</span>
 						</div>
 					</div>
 

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -1,4 +1,5 @@
 import { createVocal, isSupported as isVocalSupported, type VocalInstance } from '../src/index'
+import { watchPermission } from '@untemps/user-permissions-utils'
 
 // ── DOM refs ──────────────────────────────────────────────────────────────────
 
@@ -101,6 +102,17 @@ function setPermission(state: string) {
 	$permission.textContent = state
 }
 
+// Demo-only: reflect the current microphone permission on load (and keep it live) through the same
+// user-permissions-utils primitive vocal relies on internally — never touching `navigator` directly.
+// watchPermission emits the current state immediately, then on every transition, for the page's
+// lifetime. Vocal's own `permission` event still feeds the log during a session. Best-effort: it stays
+// silent when the Permissions API is unavailable or `microphone` isn't queryable (Safari/Firefox).
+function seedPermissionBadge() {
+	watchPermission('microphone', (state) => setPermission(state)).catch(() => {
+		/* leave the badge at its default "unknown" */
+	})
+}
+
 function resetOptions() {
 	$optLang.value = 'fr-FR'
 	$optMaxAlt.value = '3'
@@ -131,8 +143,6 @@ function initVocal() {
 
 	const options = buildOptions()
 	vocal = createVocal(options)
-
-	setPermission('unknown')
 
 	vocal.on('result', (_, best, alts) => {
 		$transcript.textContent = best
@@ -181,6 +191,7 @@ if (!isSupported) {
 	)
 } else {
 	initVocal()
+	seedPermissionBadge()
 }
 
 // ── Bindings ──────────────────────────────────────────────────────────────────

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -102,15 +102,8 @@ function setPermission(state: string) {
 	$permission.textContent = state
 }
 
-// Demo-only: reflect the current microphone permission on load (and keep it live) through the same
-// user-permissions-utils primitive vocal relies on internally — never touching `navigator` directly.
-// watchPermission emits the current state immediately, then on every transition, for the page's
-// lifetime. Vocal's own `permission` event still feeds the log during a session. Best-effort: it stays
-// silent when the Permissions API is unavailable or `microphone` isn't queryable (Safari/Firefox).
 function seedPermissionBadge() {
-	watchPermission('microphone', (state) => setPermission(state)).catch(() => {
-		/* leave the badge at its default "unknown" */
-	})
+	watchPermission('microphone', (state) => setPermission(state)).catch(() => {})
 }
 
 function resetOptions() {

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -4,6 +4,7 @@ import { createVocal, isSupported as isVocalSupported, type VocalInstance } from
 
 const $supported    = document.getElementById('status-supported')!
 const $recording    = document.getElementById('status-recording')!
+const $permission   = document.getElementById('status-permission')!
 const $transcript   = document.getElementById('result-transcript')!
 const $alternatives = document.getElementById('result-alternatives')!
 const $log          = document.getElementById('log')!
@@ -94,6 +95,12 @@ function setBadge(el: HTMLElement, value: boolean, trueClass?: string) {
 	el.textContent = String(value)
 }
 
+function setPermission(state: string) {
+	const cls = state === 'granted' ? 'yes' : state === 'denied' ? 'no' : 'warn'
+	$permission.className = `badge ${cls}`
+	$permission.textContent = state
+}
+
 function resetOptions() {
 	$optLang.value = 'fr-FR'
 	$optMaxAlt.value = '3'
@@ -125,6 +132,8 @@ function initVocal() {
 	const options = buildOptions()
 	vocal = createVocal(options)
 
+	setPermission('unknown')
+
 	vocal.on('result', (_, best, alts) => {
 		$transcript.textContent = best
 		setAlternatives(alts)
@@ -134,6 +143,12 @@ function initVocal() {
 
 	vocal.on('error', (event) => {
 		log('error', event.error ?? String(event))
+		updateStatus()
+	})
+
+	vocal.on('permission', (_event, state) => {
+		setPermission(state)
+		log('permission', state)
 		updateStatus()
 	})
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"vitest": "^4.1.5"
 	},
 	"dependencies": {
-		"@untemps/user-permissions-utils": "^1.3.3"
+		"@untemps/user-permissions-utils": "^2.2.3"
 	},
 	"peerDependencies": {
 		"typescript": ">=6.0.0"

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -78,7 +78,7 @@ export type ResultEventHandler = (
 	alternatives: string[]
 ) => void
 export type ErrorEventHandler = (event: SpeechRecognitionErrorEvent) => void
-export type PermissionEventHandler = (event: Event, state: PermissionState) => void
+export type PermissionEventHandler = (event: Event & { state: PermissionState }, state: PermissionState) => void
 export type GenericEventHandler = (event: Event) => void
 
 export type EventHandlerFor<T extends EventType> = T extends 'result'

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -333,6 +333,9 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 			isRecording = true
 			lastStartedAt = Date.now()
 		} catch (error) {
+			// Recognition never started, so don't leave the watch subscribed (the "no leak"
+			// contract only promises teardown on stop/abort/cleanup, none of which run here).
+			teardownPermissionWatch()
 			if (error instanceof Error && error.name === 'AbortError') return
 			throw error
 		}

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -304,9 +304,6 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		if (!isPermissionsSupported()) return
 		const controller = new AbortController()
 		permissionWatchController = controller
-		// Tear the watch down on the consumer signal too. AbortSignal.any is the clean fusion, but
-		// some engines expose the Permissions API without it (e.g. Safari 16.0–17.3); fall back to
-		// forwarding the abort so building the watch signal can never throw out of start().
 		let watchSignal: AbortSignal = controller.signal
 		if (signal) {
 			try {
@@ -336,8 +333,6 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 			isRecording = true
 			lastStartedAt = Date.now()
 		} catch (error) {
-			// Recognition never started, so don't leave the watch subscribed (the "no leak"
-			// contract only promises teardown on stop/abort/cleanup, none of which run here).
 			teardownPermissionWatch()
 			if (error instanceof Error && error.name === 'AbortError') return
 			throw error

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -304,7 +304,18 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		if (!isPermissionsSupported()) return
 		const controller = new AbortController()
 		permissionWatchController = controller
-		const watchSignal = signal ? AbortSignal.any([signal, controller.signal]) : controller.signal
+		// Tear the watch down on the consumer signal too. AbortSignal.any is the clean fusion, but
+		// some engines expose the Permissions API without it (e.g. Safari 16.0–17.3); fall back to
+		// forwarding the abort so building the watch signal can never throw out of start().
+		let watchSignal: AbortSignal = controller.signal
+		if (signal) {
+			try {
+				watchSignal = AbortSignal.any([signal, controller.signal])
+			} catch {
+				if (signal.aborted) controller.abort()
+				else signal.addEventListener('abort', () => controller.abort(), { once: true })
+			}
+		}
 		watchPermission('microphone', (state) => emitPermission(state), { signal: watchSignal }).catch(() => {})
 	}
 

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -67,8 +67,6 @@ export const eventTypes = {
 	SPEECH_END: 'speechend',
 	SPEECH_START: 'speechstart',
 	START: 'start',
-	// Library-synthetic event (not a native SpeechRecognition event): emitted with the current
-	// microphone permission state ('granted' | 'denied' | 'prompt') on start() and on every transition.
 	PERMISSION: 'permission',
 } as const
 
@@ -158,10 +156,6 @@ const includesEventType = (eventType: string): boolean => Object.values(eventTyp
 const unknownEventTypeMessage = (eventType: string): string =>
 	`Unknown event type "${eventType}". Valid types are: ${Object.values(eventTypes).join(', ')}.`
 
-// Permissions API is intentionally not required: getUserMediaStream drives the prompt through
-// navigator.mediaDevices, and the Permissions API is best-effort in v2. Requiring it would wrongly
-// report unsupported on browsers where SpeechRecognition + getUserMedia work but
-// navigator.permissions is absent (e.g. older Safari).
 export const isSupported = (): boolean => !!resolveSpeechRecognition() && isMediaDevicesSupported()
 
 export const createVocal = (options?: VocalOptions): VocalInstance => {
@@ -178,8 +172,6 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 	let restartTimeoutId: ReturnType<typeof setTimeout> | null = null
 	let isRestarting = false
 	let finalResults: SpeechRecognitionResult[] = []
-	// Owns the lifetime of the microphone permission watch started in start(). Aborting it removes the
-	// underlying `change` listener; stop()/abort()/cleanup() abort it so no subscription leaks.
 	let permissionWatchController: AbortController | null = null
 
 	const resolvedOptions: Required<VocalOptions> = {
@@ -245,9 +237,6 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		})
 	}
 
-	// The native instance never emits a 'permission' event, so it is dispatched synthetically here.
-	// Bypass the on() wrapper (like emitAggregatedResult) and pass the state as a second argument
-	// alongside a synthetic Event carrying it on `event.state`.
 	const emitPermission = (state: PermissionState): void => {
 		const handlers = listeners[eventTypes.PERMISSION]
 		if (!handlers?.length) return
@@ -310,20 +299,12 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 	]
 	internalListeners.forEach(([type, handler]) => instance!.addEventListener(type, handler))
 
-	// Pre-flight and session observer fused into a single watchPermission call: it emits the current
-	// state immediately (emitImmediately defaults to true), then re-emits on every transition. The
-	// subscription is torn down through permissionWatchController on stop()/abort()/cleanup(), and
-	// through the consumer signal when one is provided.
 	const observePermission = (signal?: AbortSignal): void => {
 		teardownPermissionWatch()
-		// Optional synchronous gate: skip the call on browsers without the Permissions API to avoid a
-		// guaranteed NotSupportedError rejection. The .catch below still covers non-queryable names
-		// (microphone throws a raw TypeError on Firefox/Safari even when navigator.permissions exists).
 		if (!isPermissionsSupported()) return
 		const controller = new AbortController()
 		permissionWatchController = controller
 		const watchSignal = signal ? AbortSignal.any([signal, controller.signal]) : controller.signal
-		// Best-effort: getUserMediaStream stays the path that actually surfaces the prompt.
 		watchPermission('microphone', (state) => emitPermission(state), { signal: watchSignal }).catch(() => {})
 	}
 
@@ -331,8 +312,6 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		if (!instance) return
 		observePermission(signal)
 		try {
-			// v2 resolves with a MediaStream or rejects with a typed DOMException (NotAllowedError,
-			// NotFoundError, AbortError, …) — it never resolves null, so no falsy-stream guard is needed.
 			await getUserMediaStream('microphone', { audio: true }, { signal })
 			if (signal?.aborted) return
 			// Re-check after the await: cleanup() may have nulled instance while we awaited.
@@ -343,8 +322,6 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 			isRecording = true
 			lastStartedAt = Date.now()
 		} catch (error) {
-			// AbortError (cancellation) is swallowed; every other DOMException (NotAllowedError →
-			// permission denied, NotFoundError → no device, …) propagates with its real name.
 			if (error instanceof Error && error.name === 'AbortError') return
 			throw error
 		}

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -1,4 +1,9 @@
-import { isMediaDevicesSupported, getUserMediaStream } from '@untemps/user-permissions-utils'
+import {
+	isMediaDevicesSupported,
+	isPermissionsSupported,
+	watchPermission,
+	getUserMediaStream,
+} from '@untemps/user-permissions-utils'
 
 // Web Speech API types missing from lib.dom in current TypeScript releases.
 // SpeechRecognitionEvent / SpeechRecognitionErrorEvent / SpeechRecognitionResult /
@@ -62,6 +67,9 @@ export const eventTypes = {
 	SPEECH_END: 'speechend',
 	SPEECH_START: 'speechstart',
 	START: 'start',
+	// Library-synthetic event (not a native SpeechRecognition event): emitted with the current
+	// microphone permission state ('granted' | 'denied' | 'prompt') on start() and on every transition.
+	PERMISSION: 'permission',
 } as const
 
 export type EventType = (typeof eventTypes)[keyof typeof eventTypes]
@@ -72,13 +80,16 @@ export type ResultEventHandler = (
 	alternatives: string[]
 ) => void
 export type ErrorEventHandler = (event: SpeechRecognitionErrorEvent) => void
+export type PermissionEventHandler = (event: Event, state: PermissionState) => void
 export type GenericEventHandler = (event: Event) => void
 
 export type EventHandlerFor<T extends EventType> = T extends 'result'
 	? ResultEventHandler
 	: T extends 'error'
 		? ErrorEventHandler
-		: GenericEventHandler
+		: T extends 'permission'
+			? PermissionEventHandler
+			: GenericEventHandler
 
 export interface VocalInstance {
 	readonly isRecording: boolean
@@ -167,6 +178,9 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 	let restartTimeoutId: ReturnType<typeof setTimeout> | null = null
 	let isRestarting = false
 	let finalResults: SpeechRecognitionResult[] = []
+	// Owns the lifetime of the microphone permission watch started in start(). Aborting it removes the
+	// underlying `change` listener; stop()/abort()/cleanup() abort it so no subscription leaks.
+	let permissionWatchController: AbortController | null = null
 
 	const resolvedOptions: Required<VocalOptions> = {
 		...defaultOptions,
@@ -231,6 +245,21 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		})
 	}
 
+	// The native instance never emits a 'permission' event, so it is dispatched synthetically here.
+	// Bypass the on() wrapper (like emitAggregatedResult) and pass the state as a second argument
+	// alongside a synthetic Event carrying it on `event.state`.
+	const emitPermission = (state: PermissionState): void => {
+		const handlers = listeners[eventTypes.PERMISSION]
+		if (!handlers?.length) return
+		const event = Object.assign(new Event(eventTypes.PERMISSION), { state })
+		;[...handlers].forEach(({ callback }) => callback(event, state))
+	}
+
+	const teardownPermissionWatch = (): void => {
+		permissionWatchController?.abort()
+		permissionWatchController = null
+	}
+
 	const onEnd = (event: Event): void => {
 		if (shouldAutoRestart()) {
 			// Chrome enforces a ~7s silence timeout even with continuous=true; restart transparently.
@@ -281,8 +310,26 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 	]
 	internalListeners.forEach(([type, handler]) => instance!.addEventListener(type, handler))
 
+	// Pre-flight and session observer fused into a single watchPermission call: it emits the current
+	// state immediately (emitImmediately defaults to true), then re-emits on every transition. The
+	// subscription is torn down through permissionWatchController on stop()/abort()/cleanup(), and
+	// through the consumer signal when one is provided.
+	const observePermission = (signal?: AbortSignal): void => {
+		teardownPermissionWatch()
+		// Optional synchronous gate: skip the call on browsers without the Permissions API to avoid a
+		// guaranteed NotSupportedError rejection. The .catch below still covers non-queryable names
+		// (microphone throws a raw TypeError on Firefox/Safari even when navigator.permissions exists).
+		if (!isPermissionsSupported()) return
+		const controller = new AbortController()
+		permissionWatchController = controller
+		const watchSignal = signal ? AbortSignal.any([signal, controller.signal]) : controller.signal
+		// Best-effort: getUserMediaStream stays the path that actually surfaces the prompt.
+		watchPermission('microphone', (state) => emitPermission(state), { signal: watchSignal }).catch(() => {})
+	}
+
 	const start = async ({ signal }: { signal?: AbortSignal } = {}): Promise<void> => {
 		if (!instance) return
+		observePermission(signal)
 		try {
 			// v2 resolves with a MediaStream or rejects with a typed DOMException (NotAllowedError,
 			// NotFoundError, AbortError, …) — it never resolves null, so no falsy-stream guard is needed.
@@ -307,6 +354,7 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		if (!instance) return
 		explicitStop = true
 		clearRestartTimeout()
+		teardownPermissionWatch()
 		instance.stop()
 		isRecording = false
 	}
@@ -315,6 +363,7 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		if (!instance) return
 		explicitStop = true
 		clearRestartTimeout()
+		teardownPermissionWatch()
 		// Clear before instance.abort() so the resulting 'end' → onEnd → emitAggregatedResult is a no-op.
 		finalResults = []
 		instance.abort()

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -316,7 +316,10 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 				else signal.addEventListener('abort', () => controller.abort(), { once: true })
 			}
 		}
-		watchPermission('microphone', (state) => emitPermission(state), { signal: watchSignal }).catch(() => {})
+		watchPermission('microphone', (state) => emitPermission(state), {
+			signal: watchSignal,
+			emitImmediately: true,
+		}).catch(() => {})
 	}
 
 	const start = async ({ signal }: { signal?: AbortSignal } = {}): Promise<void> => {

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -260,6 +260,8 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		}
 		// Flush here (not in stop()) so trailing finals emitted between instance.stop() and 'end' are included.
 		emitAggregatedResult()
+		// The session is over (not an auto-restart), so tear down the permission watch too.
+		teardownPermissionWatch()
 		isRecording = false
 	}
 
@@ -323,7 +325,10 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		if (!instance) return
 		observePermission(signal)
 		try {
-			await getUserMediaStream('microphone', { audio: true }, { signal })
+			const stream = await getUserMediaStream('microphone', { audio: true }, { signal })
+			// The stream is acquired only to drive the permission prompt; SpeechRecognition
+			// captures audio itself, so release these tracks immediately to free the microphone.
+			stream.getTracks().forEach((track) => track.stop())
 			if (signal?.aborted) return
 			// Re-check after the await: cleanup() may have nulled instance while we awaited.
 			if (!instance) return

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -1,8 +1,4 @@
-import {
-	isNavigatorPermissionsSupported,
-	isNavigatorMediaDevicesSupported,
-	getUserMediaStream,
-} from '@untemps/user-permissions-utils'
+import { isMediaDevicesSupported, getUserMediaStream } from '@untemps/user-permissions-utils'
 
 // Web Speech API types missing from lib.dom in current TypeScript releases.
 // SpeechRecognitionEvent / SpeechRecognitionErrorEvent / SpeechRecognitionResult /
@@ -151,8 +147,11 @@ const includesEventType = (eventType: string): boolean => Object.values(eventTyp
 const unknownEventTypeMessage = (eventType: string): string =>
 	`Unknown event type "${eventType}". Valid types are: ${Object.values(eventTypes).join(', ')}.`
 
-export const isSupported = (): boolean =>
-	!!resolveSpeechRecognition() && !!isNavigatorPermissionsSupported() && !!isNavigatorMediaDevicesSupported()
+// Permissions API is intentionally not required: getUserMediaStream drives the prompt through
+// navigator.mediaDevices, and the Permissions API is best-effort in v2. Requiring it would wrongly
+// report unsupported on browsers where SpeechRecognition + getUserMedia work but
+// navigator.permissions is absent (e.g. older Safari).
+export const isSupported = (): boolean => !!resolveSpeechRecognition() && isMediaDevicesSupported()
 
 export const createVocal = (options?: VocalOptions): VocalInstance => {
 	const SpeechRecognition = resolveSpeechRecognition()
@@ -285,19 +284,20 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 	const start = async ({ signal }: { signal?: AbortSignal } = {}): Promise<void> => {
 		if (!instance) return
 		try {
-			const stream = (await getUserMediaStream('microphone', { audio: true }, { signal })) as MediaStream | null
+			// v2 resolves with a MediaStream or rejects with a typed DOMException (NotAllowedError,
+			// NotFoundError, AbortError, …) — it never resolves null, so no falsy-stream guard is needed.
+			await getUserMediaStream('microphone', { audio: true }, { signal })
 			if (signal?.aborted) return
 			// Re-check after the await: cleanup() may have nulled instance while we awaited.
 			if (!instance) return
-			if (!stream) {
-				throw new Error('Unable to retrieve the stream from media device')
-			}
 			explicitStop = false
 			finalResults = []
 			instance.start()
 			isRecording = true
 			lastStartedAt = Date.now()
 		} catch (error) {
+			// AbortError (cancellation) is swallowed; every other DOMException (NotAllowedError →
+			// permission denied, NotFoundError → no device, …) propagates with its real name.
 			if (error instanceof Error && error.name === 'AbortError') return
 			throw error
 		}

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -30,7 +30,10 @@ const setup = (options?: Parameters<typeof createVocal>[0]): { vocal: VocalInsta
 	return { vocal, instance: lastInstance() }
 }
 
-const mockStream = 'stream' as unknown as MediaStream
+const mockTrackStop = vi.fn()
+const mockStream = {
+	getTracks: () => [{ stop: mockTrackStop } as unknown as MediaStreamTrack],
+} as unknown as MediaStream
 
 describe('Vocal', () => {
 	describe('isSupported', () => {
@@ -174,6 +177,14 @@ describe('Vocal', () => {
 			const { vocal, instance } = setup()
 			await vocal.start()
 			expect(instance.start).toHaveBeenCalled()
+		})
+
+		it('releases the acquired stream tracks once the prompt has been driven', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+			mockTrackStop.mockClear()
+			const { vocal } = setup()
+			await vocal.start()
+			expect(mockTrackStop).toHaveBeenCalledTimes(1)
 		})
 
 		it.each([
@@ -416,6 +427,22 @@ describe('Vocal', () => {
 			await vocal.start({ signal: controller.signal })
 			expect(capturedSignal?.aborted).toBe(false)
 			controller.abort()
+			expect(capturedSignal?.aborted).toBe(true)
+		})
+
+		it('tears down the watch when the session ends naturally', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+			let capturedSignal: AbortSignal | undefined
+			vi.spyOn(userPermissionsUtils, 'watchPermission').mockImplementation((_name, _onChange, options) => {
+				capturedSignal = options?.signal
+				return Promise.resolve()
+			})
+			const { vocal, instance } = setup()
+			await vocal.start()
+			expect(capturedSignal?.aborted).toBe(false)
+			;(instance.addEventListener.mock.calls as unknown as [string, EventListener][])
+				.filter(([type]) => type === 'end')
+				.forEach(([, handler]) => handler(new Event('end')))
 			expect(capturedSignal?.aborted).toBe(true)
 		})
 	})

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -310,7 +310,6 @@ describe('Vocal', () => {
 
 		it('passes microphone and an abort signal to watchPermission', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			// Emit with no listener registered to exercise the no-op dispatch path.
 			const spy = grantOnWatch('granted')
 			const { vocal } = setup()
 			await vocal.start()

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -338,6 +338,19 @@ describe('Vocal', () => {
 			expect(streamSpy).toHaveBeenCalled()
 		})
 
+		it('tears down the watch when start() rejects', async () => {
+			let capturedSignal: AbortSignal | undefined
+			vi.spyOn(userPermissionsUtils, 'watchPermission').mockImplementation((_name, _onChange, options) => {
+				capturedSignal = options?.signal
+				return Promise.resolve()
+			})
+			const error = new DOMException('permission denied', 'NotAllowedError')
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockRejectedValueOnce(error)
+			const { vocal } = setup()
+			await expect(vocal.start()).rejects.toBe(error)
+			expect(capturedSignal?.aborted).toBe(true)
+		})
+
 		it.each([
 			['stop', (v: VocalInstance) => v.stop()],
 			['abort', (v: VocalInstance) => v.abort()],

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -257,6 +257,122 @@ describe('Vocal', () => {
 		})
 	})
 
+	describe('permission event', () => {
+		const grantOnWatch = (state: PermissionState = 'granted') =>
+			vi.spyOn(userPermissionsUtils, 'watchPermission').mockImplementation((_name, onChange) => {
+				onChange(state)
+				return Promise.resolve()
+			})
+
+		it('is accepted as a valid event type', () => {
+			const { vocal } = setup()
+			expect(() => vocal.on(eventTypes.PERMISSION, vi.fn())).not.toThrow()
+		})
+
+		it('emits the current microphone permission state on start', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+			grantOnWatch('granted')
+			const onPermission = vi.fn()
+			const { vocal } = setup()
+			vocal.on(eventTypes.PERMISSION, onPermission)
+			await vocal.start()
+			expect(onPermission).toHaveBeenCalledWith(expect.any(Event), 'granted')
+		})
+
+		it('carries the state on the synthetic event', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+			grantOnWatch('granted')
+			const onPermission = vi.fn()
+			const { vocal } = setup()
+			vocal.on(eventTypes.PERMISSION, onPermission)
+			await vocal.start()
+			const event = onPermission.mock.calls[0][0] as Event & { state: PermissionState }
+			expect(event.state).toBe('granted')
+		})
+
+		it('re-emits on permission transition during the session', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+			let emit!: (state: PermissionState) => void
+			vi.spyOn(userPermissionsUtils, 'watchPermission').mockImplementation((_name, onChange) => {
+				emit = onChange
+				onChange('prompt')
+				return Promise.resolve()
+			})
+			const onPermission = vi.fn()
+			const { vocal } = setup()
+			vocal.on(eventTypes.PERMISSION, onPermission)
+			await vocal.start()
+			emit('denied')
+			expect(onPermission).toHaveBeenCalledTimes(2)
+			expect(onPermission).toHaveBeenNthCalledWith(1, expect.any(Event), 'prompt')
+			expect(onPermission).toHaveBeenNthCalledWith(2, expect.any(Event), 'denied')
+		})
+
+		it('passes microphone and an abort signal to watchPermission', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+			// Emit with no listener registered to exercise the no-op dispatch path.
+			const spy = grantOnWatch('granted')
+			const { vocal } = setup()
+			await vocal.start()
+			expect(spy).toHaveBeenCalledWith('microphone', expect.any(Function), {
+				signal: expect.any(AbortSignal),
+			})
+		})
+
+		it('does not call watchPermission when the Permissions API is unsupported', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+			vi.spyOn(userPermissionsUtils, 'isPermissionsSupported').mockReturnValue(false)
+			const spy = vi.spyOn(userPermissionsUtils, 'watchPermission')
+			const { vocal } = setup()
+			await vocal.start()
+			expect(spy).not.toHaveBeenCalled()
+		})
+
+		it('is best-effort: a rejected watchPermission does not prevent start', async () => {
+			const streamSpy = vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+			vi.spyOn(userPermissionsUtils, 'watchPermission').mockRejectedValue(
+				new DOMException('not supported', 'NotSupportedError')
+			)
+			const { vocal, instance } = setup()
+			await expect(vocal.start()).resolves.toBeUndefined()
+			expect(instance.start).toHaveBeenCalled()
+			expect(streamSpy).toHaveBeenCalled()
+		})
+
+		it.each([
+			['stop', (v: VocalInstance) => v.stop()],
+			['abort', (v: VocalInstance) => v.abort()],
+			['cleanup', (v: VocalInstance) => v.cleanup()],
+		] as const)('tears down the watch subscription on %s', async (_, action) => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+			let capturedSignal: AbortSignal | undefined
+			vi.spyOn(userPermissionsUtils, 'watchPermission').mockImplementation((_name, _onChange, options) => {
+				capturedSignal = options?.signal
+				return Promise.resolve()
+			})
+			const { vocal } = setup()
+			await vocal.start()
+			expect(capturedSignal?.aborted).toBe(false)
+			action(vocal)
+			expect(capturedSignal?.aborted).toBe(true)
+		})
+
+		it('tears down the watch when the consumer signal aborts', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+			let capturedSignal: AbortSignal | undefined
+			vi.spyOn(userPermissionsUtils, 'watchPermission').mockImplementation((_name, _onChange, options) => {
+				capturedSignal = options?.signal
+				return Promise.resolve()
+			})
+			const controller = new AbortController()
+			const { vocal } = setup()
+			await vocal.start({ signal: controller.signal })
+			expect(capturedSignal?.aborted).toBe(false)
+			controller.abort()
+			expect(capturedSignal?.aborted).toBe(true)
+		})
+	})
+
 	describe('stop', () => {
 		it('calls instance.stop', () => {
 			const { vocal, instance } = setup()

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -31,21 +31,15 @@ const setup = (options?: Parameters<typeof createVocal>[0]): { vocal: VocalInsta
 }
 
 const mockStream = 'stream' as unknown as MediaStream
-const mockNull = null as unknown as MediaStream
 
 describe('Vocal', () => {
 	describe('isSupported', () => {
-		it('returns true when SpeechRecognition, permissions and mediaDevices are all supported', () => {
+		it('returns true when SpeechRecognition and mediaDevices are both supported', () => {
 			expect(isSupported()).toBe(true)
 		})
 
-		it('returns false when navigator.permissions is not supported', () => {
-			vi.spyOn(userPermissionsUtils, 'isNavigatorPermissionsSupported').mockReturnValueOnce(false)
-			expect(isSupported()).toBe(false)
-		})
-
-		it('returns false when navigator.mediaDevices is not supported', () => {
-			vi.spyOn(userPermissionsUtils, 'isNavigatorMediaDevicesSupported').mockReturnValueOnce(false)
+		it('returns false when mediaDevices is not supported', () => {
+			vi.spyOn(userPermissionsUtils, 'isMediaDevicesSupported').mockReturnValueOnce(false)
 			expect(isSupported()).toBe(false)
 		})
 
@@ -182,10 +176,14 @@ describe('Vocal', () => {
 			expect(instance.start).toHaveBeenCalled()
 		})
 
-		it('rejects when getUserMediaStream returns null', async () => {
-			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockNull)
+		it.each([
+			['NotAllowedError', 'permission denied'],
+			['NotFoundError', 'no device'],
+		])('rejects with the original %s DOMException from getUserMediaStream', async (name, message) => {
+			const error = new DOMException(message, name)
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockRejectedValueOnce(error)
 			const { vocal } = setup()
-			await expect(vocal.start()).rejects.toThrow('Unable to retrieve the stream from media device')
+			await expect(vocal.start()).rejects.toBe(error)
 			expect(vocal.isRecording).toBe(false)
 		})
 

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -315,6 +315,7 @@ describe('Vocal', () => {
 			await vocal.start()
 			expect(spy).toHaveBeenCalledWith('microphone', expect.any(Function), {
 				signal: expect.any(AbortSignal),
+				emitImmediately: true,
 			})
 		})
 

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -356,6 +356,40 @@ describe('Vocal', () => {
 			expect(capturedSignal?.aborted).toBe(true)
 		})
 
+		it('does not break start() and still tears down when AbortSignal.any is unavailable', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+			let capturedSignal: AbortSignal | undefined
+			vi.spyOn(userPermissionsUtils, 'watchPermission').mockImplementation((_name, _onChange, options) => {
+				capturedSignal = options?.signal
+				return Promise.resolve()
+			})
+			vi.spyOn(AbortSignal, 'any').mockImplementation(() => {
+				throw new TypeError('AbortSignal.any is not a function')
+			})
+			const controller = new AbortController()
+			const { vocal, instance } = setup()
+			await expect(vocal.start({ signal: controller.signal })).resolves.toBeUndefined()
+			expect(instance.start).toHaveBeenCalled()
+			expect(capturedSignal?.aborted).toBe(false)
+			controller.abort()
+			expect(capturedSignal?.aborted).toBe(true)
+		})
+
+		it('forwards an already-aborted consumer signal when AbortSignal.any is unavailable', async () => {
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+			let capturedSignal: AbortSignal | undefined
+			vi.spyOn(userPermissionsUtils, 'watchPermission').mockImplementation((_name, _onChange, options) => {
+				capturedSignal = options?.signal
+				return Promise.resolve()
+			})
+			vi.spyOn(AbortSignal, 'any').mockImplementation(() => {
+				throw new TypeError('AbortSignal.any is not a function')
+			})
+			const { vocal } = setup()
+			await vocal.start({ signal: AbortSignal.abort() })
+			expect(capturedSignal?.aborted).toBe(true)
+		})
+
 		it('tears down the watch when the consumer signal aborts', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
 			let capturedSignal: AbortSignal | undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export type {
 	EventType,
 	ResultEventHandler,
 	ErrorEventHandler,
+	PermissionEventHandler,
 	GenericEventHandler,
 	EventHandlerFor,
 } from './Vocal'

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -10,6 +10,7 @@ Object.defineProperty(global, 'navigator', {
 interface MockPermissionStatus {
 	state: string
 	addEventListener: Mock
+	removeEventListener: Mock
 }
 
 interface MockPermissions {
@@ -42,6 +43,7 @@ global.PermissionStatus = vi.fn(function (this: MockPermissionStatus) {
 	return {
 		state: 'granted',
 		addEventListener: vi.fn(),
+		removeEventListener: vi.fn(),
 	}
 }) as unknown as new () => MockPermissionStatus
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1200,10 +1200,10 @@
     "@typescript-eslint/types" "8.59.3"
     eslint-visitor-keys "^5.0.0"
 
-"@untemps/user-permissions-utils@^1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@untemps/user-permissions-utils/-/user-permissions-utils-1.3.3.tgz#406b380bf2a38020ef679b19a3cd7fb070b3ca01"
-  integrity sha512-YYGwoVKRoGUI/Oo9ktMAfA8iHOI3WA9HMVRQGR24bwP7mNvC3Nn+BLfvyUE8uj7q6HAzIqLERUrSRDTPUMtpgw==
+"@untemps/user-permissions-utils@^2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@untemps/user-permissions-utils/-/user-permissions-utils-2.2.3.tgz#32d09618549b3b93f927850a9474401e49632b58"
+  integrity sha512-1qdITXQAI9hMNxUay1Sx4M13Ffuz8MABHI5T6Xkf3wTIYhZHBZQVHAKIhsI30jcBVx6jl68wObfjz9q0Vhu3xQ==
 
 "@vitest/coverage-v8@^4.1.5":
   version "4.1.6"


### PR DESCRIPTION
## Summary

Migrates the internal `@untemps/user-permissions-utils` dependency to **v2.2.3** and takes full advantage of the v2 primitives. `isSupported()` stays synchronous but no longer depends on the Permissions API, and `start()` now surfaces the live microphone permission state to the UI through a new synthetic `permission` event. vocal never touches `navigator` directly — all detection goes through the library. Additive and non-breaking at the signature level (the major bump itself is carried by #129).

## Changes

### Part 1 — v2 dependency + synchronous `isSupported()`
- Bump `@untemps/user-permissions-utils` `^1.3.3` → `^2.2.3` (lockfile included).
- Replace the removed `isNavigatorPermissionsSupported` / `isNavigatorMediaDevicesSupported` helpers with `isMediaDevicesSupported()`.
- `isSupported()` is now `!!resolveSpeechRecognition() && isMediaDevicesSupported()` — synchronous, Permissions-API-free. This also **fixes a latent bug**: it used to return `false` on older Safari builds that lack `navigator.permissions` even though recognition works there.
- Adopt the v2 `getUserMediaStream` contract (resolves a `MediaStream` or rejects with a typed `DOMException`) — the falsy-stream guard and its generic `Error` are gone.

### Part 2 — Optimal v2 usage in `start()`
- New **library-synthetic** `permission` event (`eventTypes.PERMISSION`), emitted with the current state on `start()` and on every transition.
- A single `watchPermission('microphone', …, { signal, emitImmediately: true })` call fuses pre-flight read + session observer.
- **Best-effort**: rejections (non-queryable `microphone` → `TypeError`; no Permissions API → `NotSupportedError`) are swallowed and `getUserMediaStream` keeps driving the prompt; an optional synchronous `isPermissionsSupported()` gate avoids a guaranteed rejection.
- **No listener leak**: the watch is torn down via an internal `AbortController` on `stop()` / `abort()` / `cleanup()`, and via the consumer `signal` (combined with `AbortSignal.any`).
- New `PermissionEventHandler` type exported; `EventHandlerFor` extended.

### Docs & demo
- README: `isSupported()` semantics, `permission` event section, `start()` error taxonomy, and a "Migration to v3" note.
- Demo: a live `permission` status badge wired to `vocal.on('permission', …)`.

## Behaviour changes (non-breaking signatures, documented in the migration note)
- `start()` now rejects with the **original `getUserMedia` `DOMException`** (`NotAllowedError` → permission denied, `NotFoundError` → no device, …) instead of `Error('Unable to retrieve the stream from media device')`. Code matching the old message string must switch to `error.name`.
- `isSupported()` widens support (returns `true` on environments without the Permissions API where vocal works) — never narrows it.

## Test plan
- [x] `yarn typecheck` passes
- [x] `yarn test:ci` passes — 97 tests, **100%** coverage maintained (statements/branches/functions/lines)
- [x] `yarn build` passes (ES + CJS)
- [x] `yarn lint` passes
- [x] `yarn dev` boots the demo cleanly; the permission badge renders and updates

Closes #130