### PR TITLE
feat(core): Expose microphone permission state outside a start() session

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Please refer to [this section](https://developer.mozilla.org/en-US/docs/Web/API/
 | speechend   | Fired when speech recognized by the recognition service has stopped being detected        |
 | speechstart | Fired when sound recognized by the recognition service as speech has been detected        |
 | start       | fired when the recognition service has begun listening to incoming audio                  |
-| permission  | **Library-synthetic** (not a native `SpeechRecognition` event). Fired with the current microphone permission state on `start()` and on every transition during the session (see [Microphone permission event](#microphone-permission-event)). |
+| permission  | **Library-synthetic** (not a native `SpeechRecognition` event). Fired with the current microphone permission state as soon as a `permission` handler is attached — even before `start()` — and on every transition while at least one handler stays subscribed (see [Microphone permission event](#microphone-permission-event)). |
 
 For convenience, `eventTypes` is exported as a constant map so consumers can reference type strings symbolically:
 
@@ -148,7 +148,7 @@ vocal.on(eventTypes.RESULT, handler)
 
 ### Microphone permission event
 
-Unlike every other event above, `permission` is **synthesised by Vocal** — the native `SpeechRecognition` instance never emits it. On `start()`, Vocal observes the microphone permission through the [Permissions API](https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API) and emits the current state immediately, then re-emits on every transition for the lifetime of the session (e.g. when the user grants or revokes access). The handler receives the state both as a second argument and on `event.state`:
+Unlike every other event above, `permission` is **synthesised by Vocal** — the native `SpeechRecognition` instance never emits it. Vocal observes the microphone permission through the [Permissions API](https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API), so you can read and track it **independently of a session**. The handler receives the state both as a second argument and on `event.state`:
 
 ```ts
 vocal.on('permission', (event, state) => {
@@ -157,7 +157,9 @@ vocal.on('permission', (event, state) => {
 })
 ```
 
-The observation is **best-effort**: it never displays a prompt itself (only `start()` does, through `getUserMediaStream`), and it stays silent on browsers where the Permissions API is unavailable or where `microphone` is not queryable (Firefox, Safari). The subscription is torn down automatically when recognition ends, on `stop()`, `abort()`, `cleanup()`, or when the `AbortSignal` passed to `start()` aborts — no listener leaks. (In continuous mode it survives the transparent auto-restarts between utterances.)
+**Subscription-driven lifecycle.** Observation begins the moment the first `permission` handler is attached — even before `start()`, e.g. to seed a "mic status" badge on page load — and the handler is emitted the current state immediately. The state is then re-emitted on every transition (e.g. when the user grants or revokes access), including across a `start()`/`stop()` cycle and the transparent auto-restarts of continuous mode. The single underlying watch is torn down automatically once the **last** `permission` handler is removed via `off('permission')` or on `cleanup()` — no listener leaks. A handler attached while the watch is already running is immediately replayed the last known state, so every subscriber sees a value without waiting for the next transition.
+
+The observation is **best-effort**: it never displays a prompt itself (only `start()` does, through `getUserMediaStream`), and it stays silent on browsers where the Permissions API is unavailable or where `microphone` is not queryable (Firefox, Safari). When there is no `permission` handler, no watch is opened at all.
 
 ## Top-level exports
 
@@ -177,7 +179,7 @@ The observation is **best-effort**: it never displays a prompt itself (only `sta
 
 ### `start({ signal? })`
 
-Starts recognition. Resolves once the engine is active. Acquires the microphone through `getUserMediaStream` and, in parallel, emits the [`permission` event](#microphone-permission-event) with the current state and on every transition.
+Starts recognition. Resolves once the engine is active. Acquires the microphone through `getUserMediaStream` (which surfaces the OS permission prompt). If a [`permission` handler](#microphone-permission-event) is subscribed, the resulting grant/deny shows up as a `permission` transition — but the watch is driven by subscription, not by `start()`.
 
 Rejects if the microphone stream cannot be acquired. The rejection is the **original `DOMException`** thrown by `getUserMedia`, so it can be discriminated by `name`:
 
@@ -191,7 +193,7 @@ Cancelling the in-flight request via the `signal` resolves (it does **not** reje
 
 | Parameter | Type          | Default     | Description                                                                   |
 | --------- | ------------- | ----------- | ----------------------------------------------------------------------------- |
-| signal    | AbortSignal   | `undefined` | Cancels the in-flight microphone request and tears down the permission watch when aborted |
+| signal    | AbortSignal   | `undefined` | Cancels the in-flight microphone request when aborted (does not affect the permission watch, which is tied to subscription) |
 
 ```js
 const controller = new AbortController()
@@ -267,6 +269,6 @@ v3 migrates the internal `@untemps/user-permissions-utils` dependency to v2. The
 - **`start()` rejection** — on a failed acquisition, `start()` now rejects with the **original `getUserMedia` `DOMException`** (`NotAllowedError`, `NotFoundError`, …) instead of the generic `Error('Unable to retrieve the stream from media device')`. Discriminate on `error.name` (see [`start()`](#start-signal-)). Code that matched the old message string must be updated.
 - **`isSupported()` no longer requires the Permissions API** — it now returns `true` whenever `SpeechRecognition` and `navigator.mediaDevices.getUserMedia` are available. This **widens** support (e.g. older Safari builds without `navigator.permissions` where recognition actually works) and never narrows it.
 
-The new [`permission` event](#microphone-permission-event) is purely additive — existing listeners are unaffected.
+The new [`permission` event](#microphone-permission-event) is purely additive — existing listeners are unaffected. It is **subscription-driven**: observation starts when the first `permission` handler is attached (even before `start()`) and stops when the last one is removed or on `cleanup()`, so the state is now observable outside a session — it is no longer tied to the `start()`/`stop()` lifecycle.
 
 Side-effect methods (`stop`, `abort`, `on`, `off`, `cleanup`) now return `void` — method chaining is no longer supported. `Vocal.eventTypes` is now exported as the top-level `eventTypes` const.

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -1,5 +1,4 @@
 import { createVocal, isSupported as isVocalSupported, type VocalInstance } from '../src/index'
-import { watchPermission } from '@untemps/user-permissions-utils'
 
 // ── DOM refs ──────────────────────────────────────────────────────────────────
 
@@ -102,10 +101,6 @@ function setPermission(state: string) {
 	$permission.textContent = state
 }
 
-function seedPermissionBadge() {
-	watchPermission('microphone', (state) => setPermission(state)).catch(() => {})
-}
-
 function resetOptions() {
 	$optLang.value = 'fr-FR'
 	$optMaxAlt.value = '3'
@@ -183,8 +178,9 @@ if (!isSupported) {
 		(b) => (b.disabled = true)
 	)
 } else {
+	// The 'permission' badge is seeded by vocal.on('permission', …) in initVocal():
+	// attaching the handler starts the watch and emits the current state immediately.
 	initVocal()
-	seedPermissionBadge()
 }
 
 // ── Bindings ──────────────────────────────────────────────────────────────────

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -178,8 +178,6 @@ if (!isSupported) {
 		(b) => (b.disabled = true)
 	)
 } else {
-	// The 'permission' badge is seeded by vocal.on('permission', …) in initVocal():
-	// attaching the handler starts the watch and emits the current state immediately.
 	initVocal()
 }
 

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -173,6 +173,7 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 	let isRestarting = false
 	let finalResults: SpeechRecognitionResult[] = []
 	let permissionWatchController: AbortController | null = null
+	let lastPermissionState: PermissionState | null = null
 
 	const resolvedOptions: Required<VocalOptions> = {
 		...defaultOptions,
@@ -237,16 +238,22 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		})
 	}
 
+	const emitPermissionTo = (callback: EventHandler, state: PermissionState): void => {
+		const event = Object.assign(new Event(eventTypes.PERMISSION), { state })
+		callback(event, state)
+	}
+
 	const emitPermission = (state: PermissionState): void => {
+		lastPermissionState = state
 		const handlers = listeners[eventTypes.PERMISSION]
 		if (!handlers?.length) return
-		const event = Object.assign(new Event(eventTypes.PERMISSION), { state })
-		;[...handlers].forEach(({ callback }) => callback(event, state))
+		;[...handlers].forEach(({ callback }) => emitPermissionTo(callback, state))
 	}
 
 	const teardownPermissionWatch = (): void => {
 		permissionWatchController?.abort()
 		permissionWatchController = null
+		lastPermissionState = null
 	}
 
 	const onEnd = (event: Event): void => {
@@ -260,8 +267,6 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		}
 		// Flush here (not in stop()) so trailing finals emitted between instance.stop() and 'end' are included.
 		emitAggregatedResult()
-		// The session is over (not an auto-restart), so tear down the permission watch too.
-		teardownPermissionWatch()
 		isRecording = false
 	}
 
@@ -301,29 +306,22 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 	]
 	internalListeners.forEach(([type, handler]) => instance!.addEventListener(type, handler))
 
-	const observePermission = (signal?: AbortSignal): void => {
-		teardownPermissionWatch()
+	// Idempotent: the watch lives for as long as there is at least one 'permission'
+	// listener, independent of the session. emitImmediately seeds every currently
+	// attached handler with the initial state.
+	const ensurePermissionWatch = (): void => {
+		if (permissionWatchController) return
 		if (!isPermissionsSupported()) return
 		const controller = new AbortController()
 		permissionWatchController = controller
-		let watchSignal: AbortSignal = controller.signal
-		if (signal) {
-			try {
-				watchSignal = AbortSignal.any([signal, controller.signal])
-			} catch {
-				if (signal.aborted) controller.abort()
-				else signal.addEventListener('abort', () => controller.abort(), { once: true })
-			}
-		}
 		watchPermission('microphone', (state) => emitPermission(state), {
-			signal: watchSignal,
+			signal: controller.signal,
 			emitImmediately: true,
 		}).catch(() => {})
 	}
 
 	const start = async ({ signal }: { signal?: AbortSignal } = {}): Promise<void> => {
 		if (!instance) return
-		observePermission(signal)
 		try {
 			const stream = await getUserMediaStream('microphone', { audio: true }, { signal })
 			// The stream is acquired only to drive the permission prompt; SpeechRecognition
@@ -338,7 +336,6 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 			isRecording = true
 			lastStartedAt = Date.now()
 		} catch (error) {
-			teardownPermissionWatch()
 			if (error instanceof Error && error.name === 'AbortError') return
 			throw error
 		}
@@ -348,7 +345,6 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		if (!instance) return
 		explicitStop = true
 		clearRestartTimeout()
-		teardownPermissionWatch()
 		instance.stop()
 		isRecording = false
 	}
@@ -357,7 +353,6 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		if (!instance) return
 		explicitStop = true
 		clearRestartTimeout()
-		teardownPermissionWatch()
 		// Clear before instance.abort() so the resulting 'end' → onEnd → emitAggregatedResult is a no-op.
 		finalResults = []
 		instance.abort()
@@ -400,6 +395,17 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 
 		if (!listeners[eventType]) listeners[eventType] = []
 		listeners[eventType].push({ callback, handler })
+
+		if (eventType === eventTypes.PERMISSION) {
+			// Start observing as soon as the first handler attaches (even before start()).
+			// If the watch is already running, the new handler missed the immediate emit,
+			// so replay the cached state to it; otherwise emitImmediately seeds it.
+			if (permissionWatchController && lastPermissionState !== null) {
+				emitPermissionTo(callback, lastPermissionState)
+			} else {
+				ensurePermissionWatch()
+			}
+		}
 	}
 
 	const off = (eventType: string, callback?: EventHandler): void => {
@@ -422,6 +428,11 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 				instance!.removeEventListener(eventType, handler as EventListener)
 			)
 			delete listeners[eventType]
+		}
+
+		// Tear the watch down once the last 'permission' handler is gone — no listener leak.
+		if (eventType === eventTypes.PERMISSION && !listeners[eventTypes.PERMISSION]?.length) {
+			teardownPermissionWatch()
 		}
 	}
 

--- a/src/Vocal.ts
+++ b/src/Vocal.ts
@@ -306,9 +306,6 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 	]
 	internalListeners.forEach(([type, handler]) => instance!.addEventListener(type, handler))
 
-	// Idempotent: the watch lives for as long as there is at least one 'permission'
-	// listener, independent of the session. emitImmediately seeds every currently
-	// attached handler with the initial state.
 	const ensurePermissionWatch = (): void => {
 		if (permissionWatchController) return
 		if (!isPermissionsSupported()) return
@@ -397,9 +394,6 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 		listeners[eventType].push({ callback, handler })
 
 		if (eventType === eventTypes.PERMISSION) {
-			// Start observing as soon as the first handler attaches (even before start()).
-			// If the watch is already running, the new handler missed the immediate emit,
-			// so replay the cached state to it; otherwise emitImmediately seeds it.
 			if (permissionWatchController && lastPermissionState !== null) {
 				emitPermissionTo(callback, lastPermissionState)
 			} else {
@@ -430,7 +424,6 @@ export const createVocal = (options?: VocalOptions): VocalInstance => {
 			delete listeners[eventType]
 		}
 
-		// Tear the watch down once the last 'permission' handler is gone — no listener leak.
 		if (eventType === eventTypes.PERMISSION && !listeners[eventTypes.PERMISSION]?.length) {
 			teardownPermissionWatch()
 		}

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -380,7 +380,6 @@ describe('Vocal', () => {
 			const handler = vi.fn()
 			const { vocal } = setup()
 			vocal.on(eventTypes.PERMISSION, handler)
-			// No watch was opened, so removing the handler must tear down cleanly (no controller).
 			expect(() => vocal.off(eventTypes.PERMISSION, handler)).not.toThrow()
 			expect(spy).not.toHaveBeenCalled()
 		})

--- a/src/__tests__/Vocal.test.ts
+++ b/src/__tests__/Vocal.test.ts
@@ -275,33 +275,64 @@ describe('Vocal', () => {
 				return Promise.resolve()
 			})
 
+		const captureWatchSignal = () => {
+			const ref: { signal?: AbortSignal } = {}
+			vi.spyOn(userPermissionsUtils, 'watchPermission').mockImplementation((_name, _onChange, options) => {
+				ref.signal = options?.signal
+				return Promise.resolve()
+			})
+			return ref
+		}
+
 		it('is accepted as a valid event type', () => {
 			const { vocal } = setup()
 			expect(() => vocal.on(eventTypes.PERMISSION, vi.fn())).not.toThrow()
 		})
 
-		it('emits the current microphone permission state on start', async () => {
-			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+		it('emits the current microphone permission state as soon as a handler subscribes', () => {
 			grantOnWatch('granted')
 			const onPermission = vi.fn()
 			const { vocal } = setup()
 			vocal.on(eventTypes.PERMISSION, onPermission)
-			await vocal.start()
 			expect(onPermission).toHaveBeenCalledWith(expect.any(Event), 'granted')
 		})
 
-		it('carries the state on the synthetic event', async () => {
-			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
+		it('observes before any start() call', () => {
+			const spy = grantOnWatch('prompt')
+			const { vocal } = setup()
+			vocal.on(eventTypes.PERMISSION, vi.fn())
+			expect(spy).toHaveBeenCalledWith('microphone', expect.any(Function), {
+				signal: expect.any(AbortSignal),
+				emitImmediately: true,
+			})
+		})
+
+		it('carries the state on the synthetic event', () => {
 			grantOnWatch('granted')
 			const onPermission = vi.fn()
 			const { vocal } = setup()
 			vocal.on(eventTypes.PERMISSION, onPermission)
-			await vocal.start()
 			const event = onPermission.mock.calls[0][0] as Event & { state: PermissionState }
 			expect(event.state).toBe('granted')
 		})
 
-		it('re-emits on permission transition during the session', async () => {
+		it('re-emits on permission transition', () => {
+			let emit!: (state: PermissionState) => void
+			vi.spyOn(userPermissionsUtils, 'watchPermission').mockImplementation((_name, onChange) => {
+				emit = onChange
+				onChange('prompt')
+				return Promise.resolve()
+			})
+			const onPermission = vi.fn()
+			const { vocal } = setup()
+			vocal.on(eventTypes.PERMISSION, onPermission)
+			emit('denied')
+			expect(onPermission).toHaveBeenCalledTimes(2)
+			expect(onPermission).toHaveBeenNthCalledWith(1, expect.any(Event), 'prompt')
+			expect(onPermission).toHaveBeenNthCalledWith(2, expect.any(Event), 'denied')
+		})
+
+		it('continues to emit transitions during an active session', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
 			let emit!: (state: PermissionState) => void
 			vi.spyOn(userPermissionsUtils, 'watchPermission').mockImplementation((_name, onChange) => {
@@ -313,137 +344,146 @@ describe('Vocal', () => {
 			const { vocal } = setup()
 			vocal.on(eventTypes.PERMISSION, onPermission)
 			await vocal.start()
-			emit('denied')
-			expect(onPermission).toHaveBeenCalledTimes(2)
-			expect(onPermission).toHaveBeenNthCalledWith(1, expect.any(Event), 'prompt')
-			expect(onPermission).toHaveBeenNthCalledWith(2, expect.any(Event), 'denied')
+			expect(vocal.isRecording).toBe(true)
+			emit('granted')
+			expect(onPermission).toHaveBeenLastCalledWith(expect.any(Event), 'granted')
 		})
 
-		it('passes microphone and an abort signal to watchPermission', async () => {
+		it('does not open a watch when no permission handler is attached', async () => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			const spy = grantOnWatch('granted')
-			const { vocal } = setup()
-			await vocal.start()
-			expect(spy).toHaveBeenCalledWith('microphone', expect.any(Function), {
-				signal: expect.any(AbortSignal),
-				emitImmediately: true,
-			})
-		})
-
-		it('does not call watchPermission when the Permissions API is unsupported', async () => {
-			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			vi.spyOn(userPermissionsUtils, 'isPermissionsSupported').mockReturnValue(false)
 			const spy = vi.spyOn(userPermissionsUtils, 'watchPermission')
 			const { vocal } = setup()
 			await vocal.start()
 			expect(spy).not.toHaveBeenCalled()
 		})
 
-		it('is best-effort: a rejected watchPermission does not prevent start', async () => {
+		it('opens a single watch even with multiple permission handlers', () => {
+			const spy = grantOnWatch('granted')
+			const { vocal } = setup()
+			vocal.on(eventTypes.PERMISSION, vi.fn())
+			vocal.on(eventTypes.PERMISSION, vi.fn())
+			expect(spy).toHaveBeenCalledTimes(1)
+		})
+
+		it('replays the cached state to a handler attached after the watch started', () => {
+			grantOnWatch('granted')
+			const late = vi.fn()
+			const { vocal } = setup()
+			vocal.on(eventTypes.PERMISSION, vi.fn())
+			vocal.on(eventTypes.PERMISSION, late)
+			expect(late).toHaveBeenCalledWith(expect.any(Event), 'granted')
+		})
+
+		it('does not call watchPermission when the Permissions API is unsupported', () => {
+			vi.spyOn(userPermissionsUtils, 'isPermissionsSupported').mockReturnValue(false)
+			const spy = vi.spyOn(userPermissionsUtils, 'watchPermission')
+			const handler = vi.fn()
+			const { vocal } = setup()
+			vocal.on(eventTypes.PERMISSION, handler)
+			// No watch was opened, so removing the handler must tear down cleanly (no controller).
+			expect(() => vocal.off(eventTypes.PERMISSION, handler)).not.toThrow()
+			expect(spy).not.toHaveBeenCalled()
+		})
+
+		it('ignores watch callbacks once every handler has been removed', () => {
+			let emit!: (state: PermissionState) => void
+			vi.spyOn(userPermissionsUtils, 'watchPermission').mockImplementation((_name, onChange) => {
+				emit = onChange
+				return Promise.resolve()
+			})
+			const handler = vi.fn()
+			const { vocal } = setup()
+			vocal.on(eventTypes.PERMISSION, handler)
+			vocal.off(eventTypes.PERMISSION, handler)
+			handler.mockClear()
+			expect(() => emit('granted')).not.toThrow()
+			expect(handler).not.toHaveBeenCalled()
+		})
+
+		it('is best-effort: a rejected watchPermission breaks neither subscribe nor start', async () => {
 			const streamSpy = vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
 			vi.spyOn(userPermissionsUtils, 'watchPermission').mockRejectedValue(
 				new DOMException('not supported', 'NotSupportedError')
 			)
 			const { vocal, instance } = setup()
+			expect(() => vocal.on(eventTypes.PERMISSION, vi.fn())).not.toThrow()
 			await expect(vocal.start()).resolves.toBeUndefined()
 			expect(instance.start).toHaveBeenCalled()
 			expect(streamSpy).toHaveBeenCalled()
 		})
 
-		it('tears down the watch when start() rejects', async () => {
-			let capturedSignal: AbortSignal | undefined
-			vi.spyOn(userPermissionsUtils, 'watchPermission').mockImplementation((_name, _onChange, options) => {
-				capturedSignal = options?.signal
-				return Promise.resolve()
-			})
-			const error = new DOMException('permission denied', 'NotAllowedError')
-			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockRejectedValueOnce(error)
+		it('tears down the watch when the last permission handler is removed', () => {
+			const watch = captureWatchSignal()
+			const handler = vi.fn()
 			const { vocal } = setup()
-			await expect(vocal.start()).rejects.toBe(error)
-			expect(capturedSignal?.aborted).toBe(true)
+			vocal.on(eventTypes.PERMISSION, handler)
+			expect(watch.signal?.aborted).toBe(false)
+			vocal.off(eventTypes.PERMISSION, handler)
+			expect(watch.signal?.aborted).toBe(true)
+		})
+
+		it('keeps the watch alive while at least one permission handler remains', () => {
+			const watch = captureWatchSignal()
+			const first = vi.fn()
+			const second = vi.fn()
+			const { vocal } = setup()
+			vocal.on(eventTypes.PERMISSION, first)
+			vocal.on(eventTypes.PERMISSION, second)
+			vocal.off(eventTypes.PERMISSION, first)
+			expect(watch.signal?.aborted).toBe(false)
+			vocal.off(eventTypes.PERMISSION, second)
+			expect(watch.signal?.aborted).toBe(true)
+		})
+
+		it('tears down the watch when all permission handlers are removed at once', () => {
+			const watch = captureWatchSignal()
+			const { vocal } = setup()
+			vocal.on(eventTypes.PERMISSION, vi.fn())
+			vocal.on(eventTypes.PERMISSION, vi.fn())
+			vocal.off(eventTypes.PERMISSION)
+			expect(watch.signal?.aborted).toBe(true)
+		})
+
+		it('tears down the watch on cleanup', () => {
+			const watch = captureWatchSignal()
+			const { vocal } = setup()
+			vocal.on(eventTypes.PERMISSION, vi.fn())
+			expect(watch.signal?.aborted).toBe(false)
+			vocal.cleanup()
+			expect(watch.signal?.aborted).toBe(true)
 		})
 
 		it.each([
 			['stop', (v: VocalInstance) => v.stop()],
 			['abort', (v: VocalInstance) => v.abort()],
-			['cleanup', (v: VocalInstance) => v.cleanup()],
-		] as const)('tears down the watch subscription on %s', async (_, action) => {
+		] as const)('keeps observing permission after %s (outside-session lifetime)', async (_, action) => {
 			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			let capturedSignal: AbortSignal | undefined
-			vi.spyOn(userPermissionsUtils, 'watchPermission').mockImplementation((_name, _onChange, options) => {
-				capturedSignal = options?.signal
-				return Promise.resolve()
-			})
+			const watch = captureWatchSignal()
 			const { vocal } = setup()
+			vocal.on(eventTypes.PERMISSION, vi.fn())
 			await vocal.start()
-			expect(capturedSignal?.aborted).toBe(false)
 			action(vocal)
-			expect(capturedSignal?.aborted).toBe(true)
+			expect(watch.signal?.aborted).toBe(false)
 		})
 
-		it('does not break start() and still tears down when AbortSignal.any is unavailable', async () => {
-			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			let capturedSignal: AbortSignal | undefined
-			vi.spyOn(userPermissionsUtils, 'watchPermission').mockImplementation((_name, _onChange, options) => {
-				capturedSignal = options?.signal
-				return Promise.resolve()
-			})
-			vi.spyOn(AbortSignal, 'any').mockImplementation(() => {
-				throw new TypeError('AbortSignal.any is not a function')
-			})
-			const controller = new AbortController()
-			const { vocal, instance } = setup()
-			await expect(vocal.start({ signal: controller.signal })).resolves.toBeUndefined()
-			expect(instance.start).toHaveBeenCalled()
-			expect(capturedSignal?.aborted).toBe(false)
-			controller.abort()
-			expect(capturedSignal?.aborted).toBe(true)
-		})
-
-		it('forwards an already-aborted consumer signal when AbortSignal.any is unavailable', async () => {
-			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			let capturedSignal: AbortSignal | undefined
-			vi.spyOn(userPermissionsUtils, 'watchPermission').mockImplementation((_name, _onChange, options) => {
-				capturedSignal = options?.signal
-				return Promise.resolve()
-			})
-			vi.spyOn(AbortSignal, 'any').mockImplementation(() => {
-				throw new TypeError('AbortSignal.any is not a function')
-			})
+		it('does not tear down the watch when start() rejects', async () => {
+			const watch = captureWatchSignal()
+			const error = new DOMException('permission denied', 'NotAllowedError')
+			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockRejectedValueOnce(error)
 			const { vocal } = setup()
-			await vocal.start({ signal: AbortSignal.abort() })
-			expect(capturedSignal?.aborted).toBe(true)
+			vocal.on(eventTypes.PERMISSION, vi.fn())
+			await expect(vocal.start()).rejects.toBe(error)
+			expect(watch.signal?.aborted).toBe(false)
 		})
 
-		it('tears down the watch when the consumer signal aborts', async () => {
-			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			let capturedSignal: AbortSignal | undefined
-			vi.spyOn(userPermissionsUtils, 'watchPermission').mockImplementation((_name, _onChange, options) => {
-				capturedSignal = options?.signal
-				return Promise.resolve()
-			})
-			const controller = new AbortController()
+		it('re-opens the watch after a teardown and a fresh subscription', () => {
+			const spy = grantOnWatch('granted')
+			const handler = vi.fn()
 			const { vocal } = setup()
-			await vocal.start({ signal: controller.signal })
-			expect(capturedSignal?.aborted).toBe(false)
-			controller.abort()
-			expect(capturedSignal?.aborted).toBe(true)
-		})
-
-		it('tears down the watch when the session ends naturally', async () => {
-			vi.spyOn(userPermissionsUtils, 'getUserMediaStream').mockResolvedValueOnce(mockStream)
-			let capturedSignal: AbortSignal | undefined
-			vi.spyOn(userPermissionsUtils, 'watchPermission').mockImplementation((_name, _onChange, options) => {
-				capturedSignal = options?.signal
-				return Promise.resolve()
-			})
-			const { vocal, instance } = setup()
-			await vocal.start()
-			expect(capturedSignal?.aborted).toBe(false)
-			;(instance.addEventListener.mock.calls as unknown as [string, EventListener][])
-				.filter(([type]) => type === 'end')
-				.forEach(([, handler]) => handler(new Event('end')))
-			expect(capturedSignal?.aborted).toBe(true)
+			vocal.on(eventTypes.PERMISSION, handler)
+			vocal.off(eventTypes.PERMISSION, handler)
+			vocal.on(eventTypes.PERMISSION, handler)
+			expect(spy).toHaveBeenCalledTimes(2)
 		})
 	})
 


### PR DESCRIPTION
## Summary

Makes the synthetic `permission` event observable **independently of a session**. Today `observePermission()` runs inside `start()` and is torn down on `stop()`/`abort()`/`cleanup()`, so there is no way to read or watch the microphone permission state before `start()` (e.g. on page load) through vocal's public API — the demo had to reach into the transitive `@untemps/user-permissions-utils` dependency to seed its badge.

Implements **Option C** from #132: the permission watch is now driven by `on('permission')` subscription instead of the session lifecycle.

## Changes

- **`src/Vocal.ts`** — the watch opens when the first `permission` handler attaches (even before `start()`) and is torn down when the **last** handler is removed via `off('permission')` or on `cleanup()`. `start()`/`stop()`/`abort()`/`onEnd` no longer manage it. A single watch is shared across handlers (idempotent), and a `lastPermissionState` cache replays the current state to handlers that attach after the watch is already running. As a side benefit, `start()` no longer opens a watch when nobody is listening.
- **`demo/main.ts`** — drop the direct `@untemps/user-permissions-utils` import and the never-torn-down `seedPermissionBadge()` helper. The badge is now seeded and updated solely by `vocal.on('permission', …)`, which observes from page load.
- **`README.md`** — document the subscription-driven lifecycle, correct the `start({ signal })` description (the signal no longer affects the watch), and update the v3 migration note.

## Behaviour changes (non-breaking signatures)

No public signature changes. One observable change — the feature itself:

- `permission` events now begin on **subscription** rather than on `start()`, and persist after `stop()`/`abort()` as long as a handler stays attached, instead of being torn down at session end. In-session emission is unchanged.

## Test plan

- [x] `yarn test:ci` — 107 tests, **100%** coverage maintained (statements/branches/functions/lines)
- [x] `yarn typecheck`
- [x] `yarn build` (ES + CJS)
- [x] `yarn lint`
- [x] `yarn dev` boots cleanly; the permission badge renders the initial state on load with no direct transitive-dep import

Closes #132