### PR TITLE
fix(demo): Clean up Gladia close timer and keep abort reachable during start

### DIFF
--- a/demo/gladiaEngine.ts
+++ b/demo/gladiaEngine.ts
@@ -29,6 +29,14 @@ export const createGladiaEngine = ({ apiKey }: GladiaConfig): SpeechEngineFactor
 			let workletNode: AudioWorkletNode | null = null
 			let source: MediaStreamAudioSourceNode | null = null
 			let closed = false
+			let closeTimer: ReturnType<typeof setTimeout> | null = null
+
+			const clearCloseTimer = (): void => {
+				if (closeTimer !== null) {
+					clearTimeout(closeTimer)
+					closeTimer = null
+				}
+			}
 
 			const releaseAudio = (): void => {
 				workletNode?.disconnect()
@@ -128,6 +136,7 @@ export const createGladiaEngine = ({ apiKey }: GladiaConfig): SpeechEngineFactor
 						}
 						if (closed) return
 						closed = true
+						clearCloseTimer()
 						releaseAudio()
 						end({ flush: true })
 					}
@@ -140,11 +149,12 @@ export const createGladiaEngine = ({ apiKey }: GladiaConfig): SpeechEngineFactor
 							socket.send(JSON.stringify({ type: 'stop_recording' }))
 						}
 						releaseAudio()
-						setTimeout(() => socket.close(), STOP_GRACE_MS)
+						closeTimer = setTimeout(() => socket.close(), STOP_GRACE_MS)
 					},
 					abort() {
 						if (closed) return
 						closed = true
+						clearCloseTimer()
 						socket.onclose = null
 						socket.close()
 						releaseAudio()

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -33,6 +33,9 @@ const $btnClearLog 		= document.getElementById('btn-clear-log') as HTMLButtonEle
 let vocal: VocalInstance | null = null
 let engineFactory: SpeechEngineFactory | null = null
 let started = false
+// True while start() is in flight (mic acquisition + cloud handshake), before the 'start' event.
+// Cloud engines make this window multi-second, so abort() must stay reachable to cancel it.
+let starting = false
 
 const env = (import.meta as unknown as { env?: Record<string, string | undefined> }).env ?? {}
 
@@ -130,9 +133,9 @@ function updateStatus() {
 		setBadge($recording, false)
 	}
 
-	$btnStart.disabled   = !vocal || started || needsMissingKey()
+	$btnStart.disabled   = !vocal || started || starting || needsMissingKey()
 	$btnStop.disabled    = !vocal || !vocal.isRecording
-	$btnAbort.disabled   = !vocal || !started
+	$btnAbort.disabled   = !vocal || (!started && !starting)
 	$btnCleanup.disabled = !vocal
 }
 
@@ -175,6 +178,7 @@ function initVocal() {
 		vocal = null
 	}
 	started = false
+	starting = false
 
 	engineFactory = currentEngineFactory()
 	const supported = isCurrentSupported()
@@ -253,10 +257,14 @@ $optEngine.addEventListener('change', () => {
 
 $btnStart.addEventListener('click', async () => {
 	if (!vocal) return
+	starting = true
+	updateStatus()
 	try {
 		await vocal.start()
 	} catch (e) {
 		log('error', String(e))
+	} finally {
+		starting = false
 	}
 	updateStatus()
 })


### PR DESCRIPTION
## Contexte

Corrections du dossier `demo/` qui n'ont pas été embarquées dans le merge de #135 (branche `feat/134-pluggable-speech-engine`). Cette PR les rattache directement sur `main`.

## Changements

- **`fix(demo): Clear the Gladia close timer on stop and abort`** — Le `setTimeout` de fermeture différée du socket Gladia (`STOP_GRACE_MS`) est désormais tracé via `closeTimer` et annulé (`clearCloseTimer`) lors de la fermeture serveur, d'un `stop` ou d'un `abort`. Évite qu'un timer résiduel ne ferme un socket déjà remplacé/rouvert.
- **`fix(demo): Keep abort reachable while start is in flight`** — Ajout d'un état `starting` dans la démo : les moteurs cloud rendent la fenêtre `start()` (acquisition micro + handshake) longue de plusieurs secondes. Le bouton Abort reste actif durant cette fenêtre pour pouvoir l'annuler, et Start est désactivé pour éviter un double départ.

Changements limités à `demo/` — pas d'impact sur le code de la librairie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)