### PR TITLE
fix(demo): Guard the starting flag against superseded start() activations

### DIFF
--- a/demo/main.ts
+++ b/demo/main.ts
@@ -36,6 +36,7 @@ let started = false
 // True while start() is in flight (mic acquisition + cloud handshake), before the 'start' event.
 // Cloud engines make this window multi-second, so abort() must stay reachable to cancel it.
 let starting = false
+let startEpoch = 0
 
 const env = (import.meta as unknown as { env?: Record<string, string | undefined> }).env ?? {}
 
@@ -179,6 +180,7 @@ function initVocal() {
 	}
 	started = false
 	starting = false
+	startEpoch++
 
 	engineFactory = currentEngineFactory()
 	const supported = isCurrentSupported()
@@ -257,6 +259,7 @@ $optEngine.addEventListener('change', () => {
 
 $btnStart.addEventListener('click', async () => {
 	if (!vocal) return
+	const myEpoch = ++startEpoch
 	starting = true
 	updateStatus()
 	try {
@@ -264,7 +267,7 @@ $btnStart.addEventListener('click', async () => {
 	} catch (e) {
 		log('error', String(e))
 	} finally {
-		starting = false
+		if (myEpoch === startEpoch) starting = false
 	}
 	updateStatus()
 })


### PR DESCRIPTION
## Contexte

Suivi de #138, qui a introduit le flag `starting` dans la démo pour garder le bouton **Abort** joignable pendant `start()`. Une revue de code a montré que ce flag rouvre, dans un cas de chevauchement, exactement la régression qu'il devait supprimer.

## Problème (finding #1 de la revue)

`starting` était un booléen unique au niveau du module, remis à `false` par le `finally` du handler **Start**. Quand deux activations de `start()` se chevauchent :

1. Moteur cloud (poignée de main multi-secondes). Clic **Start** (vocal A) → `starting=true`, `await A.start()` suspendu.
2. Pendant l'attente, l'utilisateur clique **Cleanup** (ou change une option / le moteur — ces contrôles ne sont pas désactivés pendant `starting`) → `initVocal()` remet `starting=false`, crée vocal B, réactive **Start**. Le `start()` de A n'est pas annulé (aucun signal, la session est encore `null`).
3. Clic **Start** (vocal B) → `starting=true`.
4. La poignée de main de A se termine → son `finally { starting = false }` s'exécute **alors que B est encore en cours de démarrage**.

Résultat : `$btnAbort.disabled = (!started && !starting) = true` et `$btnStart` réactivé pendant tout le démarrage de B → **Abort injoignable / Start réactivé pendant un vrai `start()`**.

## Correctif

Chaque activation reçoit un jeton monotone `startEpoch`. Le handler ne remet `starting` à `false` que si son époque capturée est toujours l'époque courante. `initVocal()` incrémente l'époque pour invalider tout `start()` en vol lors d'un teardown/recreate.

```
const myEpoch = ++startEpoch
starting = true
...
finally {
    if (myEpoch === startEpoch) starting = false
}
```

## Portée

- Démo uniquement (`demo/main.ts`) — la bibliothèque publiée n'est pas touchée.
- Pas de test automatisé : la démo n'est pas couverte par la suite Vitest (le harnais mocke `start` de façon synchrone, ce qui masque cette fenêtre asynchrone). Vérifié manuellement via le scénario ci-dessus.

## Interaction avec l'autre PR

La PR sœur `fix/demo-abort-signal-during-start` (finding #2) fait passer un `AbortSignal` à `start()` pour rendre l'abort *prompt* ; elle atténue aussi ce cas en annulant tôt le `start()` chevauchant. Les deux touchent le même handler et demanderont une réconciliation triviale au merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)