### PR TITLE
fix(demo): Pass an abort signal to start() so aborting cancels the handshake promptly

### DIFF
--- a/demo/main.ts
+++ b/demo/main.ts
@@ -37,6 +37,7 @@ let started = false
 // Cloud engines make this window multi-second, so abort() must stay reachable to cancel it.
 let starting = false
 let startEpoch = 0
+let startAbort: AbortController | null = null
 
 const env = (import.meta as unknown as { env?: Record<string, string | undefined> }).env ?? {}
 
@@ -261,13 +262,17 @@ $btnStart.addEventListener('click', async () => {
 	if (!vocal) return
 	const myEpoch = ++startEpoch
 	starting = true
+	startAbort = new AbortController()
 	updateStatus()
 	try {
-		await vocal.start()
+		await vocal.start({ signal: startAbort.signal })
 	} catch (e) {
 		log('error', String(e))
 	} finally {
-		if (myEpoch === startEpoch) starting = false
+		if (myEpoch === startEpoch) {
+			starting = false
+			startAbort = null
+		}
 	}
 	updateStatus()
 })
@@ -278,6 +283,7 @@ $btnStop.addEventListener('click', () => {
 })
 
 $btnAbort.addEventListener('click', () => {
+	startAbort?.abort()
 	vocal?.abort()
 	updateStatus()
 })


### PR DESCRIPTION
## Contexte

Suivi de #138, qui a rendu le bouton **Abort** *cliquable* pendant `start()`. Une revue de code a montré que le bouton est joignable mais que son effet est *différé*, pas *prompt*.

## Problème (finding #2 de la revue)

La démo attendait `vocal.start()` **sans `AbortSignal`**. La machinerie d'abort par signal du moteur Gladia n'était donc jamais armée. Cliquer **Abort** pendant la poignée de main cloud multi-secondes ne faisait que positionner `cancelStart` dans le cœur : `getUserMedia` et l'ouverture du WebSocket allaient **jusqu'au bout**, et la session n'était démontée qu'**après** résolution de `connect()` — micro resté chaud entre-temps. Le bouton était cliquable mais son effet reporté.

## Correctif

Un `AbortController` par `start()`, son `signal` passé à `vocal.start({ signal })`, et l'abort déclenché depuis le handler **Abort**. Le cœur propage déjà ce signal jusqu'à `getUserMediaStream` et `backend.connect()` (`createEngine.ts`), donc la poignée de main est désormais annulée **immédiatement**. L'`AbortError` est absorbée par le cœur (`if (error.name === 'AbortError') return`), donc aucune erreur n'est journalisée.

```
starting = true
startAbort = new AbortController()
...
await vocal.start({ signal: startAbort.signal })
...
// handler Abort
startAbort?.abort()
vocal?.abort()
```

## Portée

- Démo uniquement (`demo/main.ts`) — la bibliothèque publiée n'est pas touchée. L'API publique `start(options?: { signal?: AbortSignal })` accepte déjà un signal ; seule la démo ne le fournissait pas.
- Pas de test automatisé : la démo n'est pas couverte par la suite Vitest. Vérifié manuellement (Abort pendant la poignée de main cloud → annulation immédiate, micro relâché, pas d'erreur journalisée).

## Interaction avec l'autre PR

La PR sœur `fix/demo-starting-epoch` (#139, finding #1) corrige le désync du flag `starting`. Les deux touchent le même handler `Start`/`Abort` et demanderont une réconciliation triviale au merge. Ce correctif-ci atténue également #1 en annulant tôt un `start()` chevauchant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)