### PR TITLE
chore(deps): Upgrade @semantic-release/github to 12.0.9 to fix the release job

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"@eslint/js": "^10.0.1",
 		"@semantic-release/changelog": "^6.0.3",
 		"@semantic-release/git": "^10.0.1",
-		"@semantic-release/github": "^12.0.6",
+		"@semantic-release/github": "^12.0.9",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@vitest/coverage-v8": "^4.1.5",
 		"eslint": "^10.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -908,10 +908,33 @@
     micromatch "^4.0.0"
     p-reduce "^2.0.0"
 
-"@semantic-release/github@^12.0.0", "@semantic-release/github@^12.0.6":
+"@semantic-release/github@^12.0.0":
   version "12.0.8"
   resolved "https://registry.yarnpkg.com/@semantic-release/github/-/github-12.0.8.tgz#536a5ce489692674f5cc51a1f9739489ae09a35c"
   integrity sha512-tej5AAgK5X9wHRoDmYhecMXEHEkFeGOY1XsEblKxu8pIQwahzf1STYyr7iPU6Lpbg6C5I3N2w/ocXrBo+L7jhw==
+  dependencies:
+    "@octokit/core" "^7.0.0"
+    "@octokit/plugin-paginate-rest" "^14.0.0"
+    "@octokit/plugin-retry" "^8.0.0"
+    "@octokit/plugin-throttling" "^11.0.0"
+    "@semantic-release/error" "^4.0.0"
+    aggregate-error "^5.0.0"
+    debug "^4.3.4"
+    dir-glob "^3.0.1"
+    http-proxy-agent "^9.0.0"
+    https-proxy-agent "^9.0.0"
+    issue-parser "^7.0.0"
+    lodash-es "^4.17.21"
+    mime "^4.0.0"
+    p-filter "^4.0.0"
+    tinyglobby "^0.2.14"
+    undici "^7.0.0"
+    url-join "^5.0.0"
+
+"@semantic-release/github@^12.0.9":
+  version "12.0.9"
+  resolved "https://registry.yarnpkg.com/@semantic-release/github/-/github-12.0.9.tgz#1cd28dafdad398fe423fd94578da772dbfb27d6a"
+  integrity sha512-ODIqb0V3QqndipryEEiaBxUQCFjvv7Oese5Dt4omMGa60YRNEW0Sx3K+zri0uac2Y6S9nOlMehciWIzvvRCTGQ==
   dependencies:
     "@octokit/core" "^7.0.0"
     "@octokit/plugin-paginate-rest" "^14.0.0"


### PR DESCRIPTION
## Constat

Depuis `v2.3.0`, le job **Publish package** échoue au step `npx semantic-release` → plugin `@semantic-release/github`, à l'**upload des assets**, avec :

```
RequestError [HttpError]: invalid content-length header
  [cause]: InvalidArgumentError: invalid content-length header  (UND_ERR_INVALID_ARG)
      at processHeader (node:internal/deps/undici) / new Request(...)   ← requête sortante, response: undefined
```

### Cause racine (vérifiée)
- `@semantic-release/github@12.0.8` (épinglé dans `yarn.lock`) positionne **manuellement** l'en-tête `content-length` sur la requête d'upload — `lib/publish.js:141` → `"content-length": file.size`.
- Le runner est passé de **Node 24.17.0** (undici 7.25.0, tolérant) à **Node 24.18.0** (undici **7.28.0**, durcissement sécurité) — le workflow n'épingle que `node-version: '24'`. L'undici 7.28.0 **rejette** un `content-length` fourni par l'appelant (en-tête de requête interdit par fetch) → l'erreur ci-dessus, 3 retries épuisés, job en échec.
- `v2.2.0` (18 juin, undici 7.25.0) passait ; `v2.3.0` (4 juillet, undici 7.28.0) casse. Même workflow, runtime undici plus strict.

### Conséquence
npm + tag + commit `chore(release)` aboutissaient, mais la release GitHub restait en **draft non publié, sans assets** (le plugin crée le draft, échoue à l'upload avant de le publier).

## Correctif
Bump `@semantic-release/github` **12.0.8 → 12.0.9** (publié le 1ᵉʳ juillet, issue [#1224](https://github.com/semantic-release/github/issues/1224)). 12.0.9 :
- *asset-upload: stop setting content-length header manually*,
- *local-undici: always use the locally installed undici instead of the node built-in version*,
- *publish: handle content-length header properly*.

Vérifié en local : le code installé 12.0.9 ne pose plus l'en-tête `content-length`, et prend `undici ^7.0.0` en dépendance directe. `yarn.lock` bougé (la CI utilise `--frozen-lockfile`).

## Notes
- Ce commit `chore(deps)` **déclenchera une release patch** (2.3.4) au merge — ce qui **valide** le pipeline réparé de bout en bout (release publiée + assets attachés).
- Les 4 drafts coincés (v2.3.0 → v2.3.3) ont déjà été **publiés manuellement** hors-CI (npm et tags étaient déjà OK).
- Épingler un patch Node 24 exact reste optionnel — le fix `local-undici` de 12.0.9 neutralise déjà la dérive undici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)