### PR TITLE
chore(deps): Force @semantic-release/github to 12.0.9 via resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
 	"dependencies": {
 		"@untemps/user-permissions-utils": "^2.2.3"
 	},
+	"resolutions": {
+		"@semantic-release/github": "^12.0.9"
+	},
 	"peerDependencies": {
 		"typescript": ">=6.0.0"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -908,30 +908,7 @@
     micromatch "^4.0.0"
     p-reduce "^2.0.0"
 
-"@semantic-release/github@^12.0.0":
-  version "12.0.8"
-  resolved "https://registry.yarnpkg.com/@semantic-release/github/-/github-12.0.8.tgz#536a5ce489692674f5cc51a1f9739489ae09a35c"
-  integrity sha512-tej5AAgK5X9wHRoDmYhecMXEHEkFeGOY1XsEblKxu8pIQwahzf1STYyr7iPU6Lpbg6C5I3N2w/ocXrBo+L7jhw==
-  dependencies:
-    "@octokit/core" "^7.0.0"
-    "@octokit/plugin-paginate-rest" "^14.0.0"
-    "@octokit/plugin-retry" "^8.0.0"
-    "@octokit/plugin-throttling" "^11.0.0"
-    "@semantic-release/error" "^4.0.0"
-    aggregate-error "^5.0.0"
-    debug "^4.3.4"
-    dir-glob "^3.0.1"
-    http-proxy-agent "^9.0.0"
-    https-proxy-agent "^9.0.0"
-    issue-parser "^7.0.0"
-    lodash-es "^4.17.21"
-    mime "^4.0.0"
-    p-filter "^4.0.0"
-    tinyglobby "^0.2.14"
-    undici "^7.0.0"
-    url-join "^5.0.0"
-
-"@semantic-release/github@^12.0.9":
+"@semantic-release/github@^12.0.0", "@semantic-release/github@^12.0.9":
   version "12.0.9"
   resolved "https://registry.yarnpkg.com/@semantic-release/github/-/github-12.0.9.tgz#1cd28dafdad398fe423fd94578da772dbfb27d6a"
   integrity sha512-ODIqb0V3QqndipryEEiaBxUQCFjvv7Oese5Dt4omMGa60YRNEW0Sx3K+zri0uac2Y6S9nOlMehciWIzvvRCTGQ==


### PR DESCRIPTION
## Contexte

Suite de #141. Ce PR corrigeait la vraie cause (`@semantic-release/github` 12.0.8 pose l'en-tête `content-length` que l'undici de Node 24.18.0 rejette), **mais le merge a de nouveau échoué en CI** avec la même erreur.

## Cause de l'échec de #141

`@semantic-release/github` est présent **deux fois** dans l'arbre :
1. **devDependency directe** du projet → #141 l'a passée à `^12.0.9` → 12.0.9 ✅
2. **dépendance transitive de `semantic-release`** (`@semantic-release/github@^12.0.0`) → le lock l'a laissée en **12.0.8** ❌

`npx semantic-release` charge ses plugins via *sa propre* résolution → il a pris la copie **12.0.8**. Preuve dans le log du run en échec :

```
user-agent: '@semantic-release/github v12.0.8 …'
content-length: 8555
InvalidArgumentError: invalid content-length header
```

Lockfile fusionné après #141 :
```
"@semantic-release/github@^12.0.0":   version "12.0.8"   ← toujours 12.0.8
"@semantic-release/github@^12.0.9":   version "12.0.9"
```

## Correctif

Champ `resolutions` forçant **toutes** les résolutions du plugin vers `^12.0.9` :

```json
"resolutions": {
  "@semantic-release/github": "^12.0.9"
}
```

Après `yarn install`, les deux descripteurs fusionnent en une seule entrée 12.0.9 :
```
"@semantic-release/github@^12.0.0", "@semantic-release/github@^12.0.9":
  version "12.0.9"
```
Vérifié en local : **une seule copie** dans `node_modules` (12.0.9, aucune 12.0.8), et son `publish.js` ne pose plus l'en-tête `content-length`.

## Notes
- Le merge déclenchera une release **2.3.5** qui validera réellement le pipeline (release publiée + assets attachés).
- Le draft **v2.3.4** laissé coincé par le run en échec de #141 a été publié + assets reconstruits hors-CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)